### PR TITLE
[14.0] webservice: improve call

### DIFF
--- a/webservice/components/request_adapter.py
+++ b/webservice/components/request_adapter.py
@@ -13,14 +13,14 @@ class BaseRestRequestsAdapter(Component):
     _inherit = "base.webservice.adapter"
     _webservice_protocol = "http"
 
-    def _request(self, method, **kwargs):
+    # TODO: url and url_params could come from work_ctx
+    def _request(self, method, url=None, url_params=None, **kwargs):
+        url = self._get_url(url=url, url_params=url_params)
         new_kwargs = kwargs.copy()
         new_kwargs.update(
             {"auth": self._get_auth(**kwargs), "headers": self._get_headers(**kwargs)}
         )
-        request = requests.request(
-            method, self.collection.url.format(**kwargs), **new_kwargs
-        )
+        request = requests.request(method, url, **new_kwargs)
         request.raise_for_status()
         return request.content
 
@@ -47,3 +47,11 @@ class BaseRestRequestsAdapter(Component):
         if isinstance(headers, dict):
             result.update(headers)
         return result
+
+    def _get_url(self, url=None, url_params=None, **kwargs):
+        if not url:
+            # TODO: if url is given, we should validate the domain
+            # to avoid abusing a webservice backend for different calls.
+            url = self.collection.url
+        url_params = url_params or kwargs
+        return url.format(**url_params)

--- a/webservice/tests/test_webservice.py
+++ b/webservice/tests/test_webservice.py
@@ -31,7 +31,7 @@ class TestWebService(CommonWebService):
         responses.add(responses.GET, self.url, body="{}")
         result = self.webservice.call("get")
         self.assertEqual(result, b"{}")
-        self.assertEqual(1, len(responses.calls))
+        self.assertEqual(len(responses.calls), 1)
         self.assertEqual(
             responses.calls[0].request.headers["Content-Type"], "application/xml"
         )
@@ -62,7 +62,7 @@ class TestWebService(CommonWebService):
         responses.add(responses.GET, self.url, body="{}")
         result = self.webservice.call("get")
         self.assertEqual(result, b"{}")
-        self.assertEqual(1, len(responses.calls))
+        self.assertEqual(len(responses.calls), 1)
         self.assertEqual(
             responses.calls[0].request.headers["Content-Type"], "application/xml"
         )
@@ -75,7 +75,7 @@ class TestWebService(CommonWebService):
         responses.add(responses.GET, self.url, body="{}")
         result = self.webservice.call("get", auth=("user2", "pass2"))
         self.assertEqual(result, b"{}")
-        self.assertEqual(1, len(responses.calls))
+        self.assertEqual(len(responses.calls), 1)
         self.assertEqual(
             responses.calls[0].request.headers["Content-Type"], "application/xml"
         )
@@ -87,7 +87,36 @@ class TestWebService(CommonWebService):
         responses.add(responses.GET, self.url, body="{}")
         result = self.webservice.call("get", headers={"demo_header": "HEADER"})
         self.assertEqual(result, b"{}")
-        self.assertEqual(1, len(responses.calls))
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.headers["Content-Type"], "application/xml"
+        )
+        self.assertEqual(responses.calls[0].request.headers["demo_header"], "HEADER")
+
+    @responses.activate
+    def test_web_service_call_args(self):
+        url = "https://custom.url"
+        responses.add(responses.POST, url, body="{}")
+        result = self.webservice.call(
+            "post", url=url, headers={"demo_header": "HEADER"}
+        )
+        self.assertEqual(result, b"{}")
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.headers["Content-Type"], "application/xml"
+        )
+        self.assertEqual(responses.calls[0].request.headers["demo_header"], "HEADER")
+
+        url = self.url + "custom/path"
+        self.webservice.url += "{endpoint}"
+        responses.add(responses.POST, url, body="{}")
+        result = self.webservice.call(
+            "post",
+            url_params={"endpoint": "custom/path"},
+            headers={"demo_header": "HEADER"},
+        )
+        self.assertEqual(result, b"{}")
+        self.assertEqual(len(responses.calls), 2)
         self.assertEqual(
             responses.calls[0].request.headers["Content-Type"], "application/xml"
         )


### PR DESCRIPTION
'call' now accepts these explicit kw params:

* 'url': to override the request's url completely
* 'url_params': to pass interpolation params for url formatting.