### PR TITLE
[15.0] [IMP] webservice: combine the url with collection's url

### DIFF
--- a/webservice/components/request_adapter.py
+++ b/webservice/components/request_adapter.py
@@ -60,8 +60,14 @@ class BaseRestRequestsAdapter(Component):
 
     def _get_url(self, url=None, url_params=None, **kwargs):
         if not url:
-            # TODO: if url is given, we should validate the domain
-            # to avoid abusing a webservice backend for different calls.
             url = self.collection.url
+        elif not url.startswith(self.collection.url):
+            if not url.startswith("http"):
+                url = f"{self.collection.url.rstrip('/')}/{url.lstrip('/')}"
+            else:
+                # TODO: if url is given, we should validate the domain
+                # to avoid abusing a webservice backend for different calls.
+                pass
+
         url_params = url_params or kwargs
         return url.format(**url_params)

--- a/webservice/tests/test_webservice.py
+++ b/webservice/tests/test_webservice.py
@@ -89,6 +89,28 @@ class TestWebService(CommonWebService):
         )
 
     @responses.activate
+    def test_web_service_get_url_combine(self):
+        endpoint = "api/test"
+        responses.add(responses.GET, self.url + endpoint, body="{}")
+        result = self.webservice.call("get", url="api/test")
+        self.assertEqual(result, b"{}")
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.headers["Content-Type"], "application/xml"
+        )
+
+    @responses.activate
+    def test_web_service_get_url_combine_full_url(self):
+        endpoint = "api/test"
+        responses.add(responses.GET, self.url + endpoint, body="{}")
+        result = self.webservice.call("get", url="http://localhost.demo.odoo/api/test")
+        self.assertEqual(result, b"{}")
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.headers["Content-Type"], "application/xml"
+        )
+
+    @responses.activate
     def test_web_service_post(self):
         responses.add(responses.POST, self.url, body="{}")
         result = self.webservice.call("post", data="demo_response")


### PR DESCRIPTION
when a call is made with just a path, combine it with the collection's url

better combination of urls (Co-authored-by: Simone Orsi <simahawk@users.noreply.github.com>):

bacport of #36 