### PR TITLE
[FIX] webservice: WARNING message in logs

### DIFF
--- a/webservice/models/webservice_backend.py
+++ b/webservice/models/webservice_backend.py
@@ -123,8 +123,8 @@ class WebserviceBackend(models.Model):
 
     @api.onchange("auth_type")
     def _onchange_oauth2_auth_type(self):
-        # reset the auth2_flow when auth_type is not oaut2
-        # using a compute method interfers with the server environment mixin
+        # reset the oauth2_flow when auth_type is not oauth2
+        # using a compute method interferes with the server environment mixin
         for rec in self:
             if rec.auth_type != "oauth2":
                 rec.oauth2_flow = False

--- a/webservice/models/webservice_backend.py
+++ b/webservice/models/webservice_backend.py
@@ -40,7 +40,6 @@ class WebserviceBackend(models.Model):
         ],
         readonly=False,
         store=True,
-        compute="_compute_oauth2_flow",
     )
     oauth2_clientid = fields.Char(string="Client ID", auth_type="oauth2")
     oauth2_client_secret = fields.Char(string="Client Secret", auth_type="oauth2")
@@ -122,8 +121,10 @@ class WebserviceBackend(models.Model):
             protocol += f"+{self.auth_type}-{self.oauth2_flow}"
         return protocol
 
-    @api.depends("auth_type")
-    def _compute_oauth2_flow(self):
+    @api.onchange("auth_type")
+    def _onchange_oauth2_auth_type(self):
+        # reset the auth2_flow when auth_type is not oaut2
+        # using a compute method interfers with the server environment mixin
         for rec in self:
             if rec.auth_type != "oauth2":
                 rec.oauth2_flow = False

--- a/webservice/models/webservice_backend.py
+++ b/webservice/models/webservice_backend.py
@@ -39,7 +39,6 @@ class WebserviceBackend(models.Model):
             ("web_application", "Web Application (Authorization Code Grant)"),
         ],
         readonly=False,
-        store=True,
     )
     oauth2_clientid = fields.Char(string="Client ID", auth_type="oauth2")
     oauth2_client_secret = fields.Char(string="Client Secret", auth_type="oauth2")
@@ -121,14 +120,6 @@ class WebserviceBackend(models.Model):
             protocol += f"+{self.auth_type}-{self.oauth2_flow}"
         return protocol
 
-    @api.onchange("auth_type")
-    def _onchange_oauth2_auth_type(self):
-        # reset the oauth2_flow when auth_type is not oauth2
-        # using a compute method interferes with the server environment mixin
-        for rec in self:
-            if rec.auth_type != "oauth2":
-                rec.oauth2_flow = False
-
     @api.depends("auth_type", "oauth2_flow")
     def _compute_redirect_url(self):
         get_param = self.env["ir.config_parameter"].sudo().get_param
@@ -178,3 +169,10 @@ class WebserviceBackend(models.Model):
         }
         webservice_fields.update(base_fields)
         return webservice_fields
+
+    def _compute_server_env(self):
+        # OVERRIDE: reset ``oauth2_flow`` when ``auth_type`` is not "oauth2", even if
+        # defined otherwise in server env vars
+        res = super(WebserviceBackend, self)._compute_server_env()
+        self.filtered(lambda r: r.auth_type != "oauth2").oauth2_flow = None
+        return res

--- a/webservice/tests/test_oauth2.py
+++ b/webservice/tests/test_oauth2.py
@@ -236,10 +236,12 @@ class TestWebServiceOauth2WebApplication(CommonWebService):
 
         # Update configuration: ``auth_type`` is reverted to ``oauth2``,
         # and ``oauth2_flow`` is updated to ``backend_application``
-        env["SERVER_ENV_CONFIG"] = env["SERVER_ENV_CONFIG"].replace(
-            "auth_type = none", "auth_type = oauth2"
-        ).replace(
-            "oauth2_flow = web_application", "oauth2_flow = backend_application"
+        env["SERVER_ENV_CONFIG"] = (
+            env["SERVER_ENV_CONFIG"]
+            .replace("auth_type = none", "auth_type = oauth2")
+            .replace(
+                "oauth2_flow = web_application", "oauth2_flow = backend_application"
+            )
         )
         server_env_mixin.serv_config = server_env._load_config()  # Reload env vars
         self.webservice.invalidate_recordset()  # Clear cache => read forces compute


### PR DESCRIPTION
The use of a compute method on `oauth2_flow` when this field is touched by the server environment mixin causes it to be defined twice as computed, with differents settings, and this ultimately causes a warning message in the logs:

```
WARNING odoo odoo.modules.registry: webservice.backend: inconsistent 'compute_sudo' for computed fields: protocol, url, auth_type, username, password, api_key, api_key_header, oauth2_flow, oauth2_clientid, oauth2_client_secret, oauth2_token_url, oauth2_authorization_url, oauth2_audience, oauth2_scope, content_type
```

We fix this by using an old fashioned onchange declaration on the `auth_type` field.
