### PR TITLE
[16.0][IMP] webservice: allow to return response object on http calls

### DIFF
--- a/webservice/README.rst
+++ b/webservice/README.rst
@@ -28,7 +28,9 @@ WebService
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This module creates WebService frameworks to be used globally
+This module creates WebService frameworks to be used globally.
+
+The module introduces support for HTTP Request protocol. The webservice HTTP call returns by default the content of the response. A context 'content_only' can be passed to get the full response object.
 
 **Table of contents**
 

--- a/webservice/components/request_adapter.py
+++ b/webservice/components/request_adapter.py
@@ -24,6 +24,7 @@ class BaseRestRequestsAdapter(Component):
     # TODO: url and url_params could come from work_ctx
     def _request(self, method, url=None, url_params=None, **kwargs):
         url = self._get_url(url=url, url_params=url_params)
+        content_only = kwargs.pop("content_only", True)
         new_kwargs = kwargs.copy()
         new_kwargs.update(
             {
@@ -35,7 +36,9 @@ class BaseRestRequestsAdapter(Component):
         # pylint: disable=E8106
         request = requests.request(method, url, **new_kwargs)
         request.raise_for_status()
-        return request.content
+        if content_only:
+            return request.content
+        return request
 
     def get(self, **kwargs):
         return self._request("get", **kwargs)

--- a/webservice/readme/DESCRIPTION.rst
+++ b/webservice/readme/DESCRIPTION.rst
@@ -1,1 +1,3 @@
-This module creates WebService frameworks to be used globally
+This module creates WebService frameworks to be used globally.
+
+The module introduces support for HTTP Request protocol. The webservice HTTP call returns by default the content of the response. A context 'content_only' can be passed to get the full response object.

--- a/webservice/static/description/index.html
+++ b/webservice/static/description/index.html
@@ -369,7 +369,8 @@ ul.auto-toc {
 !! source digest: sha256:121c86ad41210631fb9ae34436323a42c1d704ae098de31f93ce8f7c259140ce
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Production/Stable" src="https://img.shields.io/badge/maturity-Production%2FStable-green.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/web-api/tree/16.0/webservice"><img alt="OCA/web-api" src="https://img.shields.io/badge/github-OCA%2Fweb--api-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/web-api-16-0/web-api-16-0-webservice"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/web-api&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This module creates WebService frameworks to be used globally</p>
+<p>This module creates WebService frameworks to be used globally.</p>
+<p>The module introduces support for HTTP Request protocol. The webservice HTTP call returns by default the content of the response. A context ‘content_only’ can be passed to get the full response object.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">


### PR DESCRIPTION
you may need to use information on the headers of the response