### PR TITLE
[16.0] endpoint: add log function

### DIFF
--- a/endpoint/tests/test_endpoint.py
+++ b/endpoint/tests/test_endpoint.py
@@ -94,6 +94,24 @@ class TestEndpoint(CommonEndpoint):
         payload = result["payload"]
         self.assertEqual(json.loads(payload), {"a": 1, "b": 2})
 
+    def test_endpoint_log(self):
+        self.endpoint.write(
+            {
+                "code_snippet": textwrap.dedent(
+                    """
+            log("ciao")
+            result = {"ok": True}
+            """
+                )
+            }
+        )
+        with self._get_mocked_request() as req:
+            # just test that logging does not break
+            # as it creates a record directly via sql
+            # and we cannot easily check the result
+            self.endpoint._handle_request(req)
+        self.env.cr.execute("DELETE FROM ir_logging")
+
     @mute_logger("endpoint.endpoint", "odoo.modules.registry")
     def test_endpoint_validate_request(self):
         endpoint = self.endpoint.copy(


### PR DESCRIPTION
Very handy especially to log errors w/o providing much info to the caller.


FWD port of #49 