### PR TITLE
[16.0][FWD] endpoint: add basic mixin view

### DIFF
--- a/endpoint/views/endpoint_view.xml
+++ b/endpoint/views/endpoint_view.xml
@@ -3,9 +3,10 @@
      License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
 <odoo>
 
-    <record model="ir.ui.view" id="endpoint_endpoint_form_view">
-        <field name="name">endpoint.endpoint.form</field>
-        <field name="model">endpoint.endpoint</field>
+    <!-- Basic view inheritable by real models -->
+    <record model="ir.ui.view" id="endpoint_mixin_form_view">
+        <field name="name">endpoint.mixin.form</field>
+        <field name="model">endpoint.mixin</field>
         <field name="arch" type="xml">
             <form>
                 <header />
@@ -87,6 +88,19 @@
                     </notebook>
                 </sheet>
             </form>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="endpoint_endpoint_form_view">
+        <field name="name">endpoint.endpoint.form</field>
+        <field name="model">endpoint.endpoint</field>
+        <field name="inherit_id" ref="endpoint.endpoint_mixin_form_view" />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+          <form position="attributes">
+            <!-- Needed just to make further inheritance happy -->
+            <attribute name="name">real</attribute>
+          </form>
         </field>
     </record>
 

--- a/endpoint_auth_api_key/views/endpoint_view.xml
+++ b/endpoint_auth_api_key/views/endpoint_view.xml
@@ -3,9 +3,9 @@
      License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
 <odoo>
 
-    <record model="ir.ui.view" id="endpoint_endpoint_form_view">
+    <record model="ir.ui.view" id="endpoint_mixin_form_view">
         <field name="model">endpoint.endpoint</field>
-        <field name="inherit_id" ref="endpoint.endpoint_endpoint_form_view" />
+        <field name="inherit_id" ref="endpoint.endpoint_mixin_form_view" />
         <field name="arch" type="xml">
             <group name="auth" position="inside">
                 <field


### PR DESCRIPTION
As the mixin can be inherited by many other models w/ their view an isolated basic view is required to avoid pollution and breakage of inherited views when extending the views of endpoint.endpoint.

In particular, this solves a conflict that came w/ https://github.com/OCA/web-api-contrib/pull/1


FWD port of #56 