### PR TITLE
[14.0] endpoint_*: fix mixin view override

### DIFF
--- a/endpoint_auth_api_key/views/endpoint_view.xml
+++ b/endpoint_auth_api_key/views/endpoint_view.xml
@@ -4,7 +4,7 @@
 <odoo>
 
     <record model="ir.ui.view" id="endpoint_mixin_form_view">
-        <field name="model">endpoint.endpoint</field>
+        <field name="model">endpoint.mixin</field>
         <field name="inherit_id" ref="endpoint.endpoint_mixin_form_view" />
         <field name="arch" type="xml">
             <group name="auth" position="inside">

--- a/endpoint_cache/views/endpoint_view.xml
+++ b/endpoint_cache/views/endpoint_view.xml
@@ -4,7 +4,7 @@
 <odoo>
 
     <record model="ir.ui.view" id="endpoint_mixin_form_view">
-        <field name="model">endpoint.endpoint</field>
+        <field name="model">endpoint.mixin</field>
         <field name="inherit_id" ref="endpoint.endpoint_mixin_form_view" />
         <field name="arch" type="xml">
           <notebook>


### PR DESCRIPTION
Followup of https://github.com/OCA/web-api/pull/5
The view must be registered for the mixin model otherwise it won't be taken into account.
I've probably left this change in a stashed version :(