### PR TITLE
[16.0][FIX]  authorization

### DIFF
--- a/webservice/components/request_adapter.py
+++ b/webservice/components/request_adapter.py
@@ -240,6 +240,7 @@ class WebApplicationOAuth2RestRequestsAdapter(Component):
         with OAuth2Session(
             client=client,
             redirect_uri=oauth_params.get("redirect_url"),
+            scope=oauth_params.get("oauth2_scope"),
         ) as session:
             authorization_url, state = session.authorization_url(
                 backend.oauth2_authorization_url, **authorization_url_extra_params

--- a/webservice/controllers/oauth2.py
+++ b/webservice/controllers/oauth2.py
@@ -46,7 +46,7 @@ class OAuth2Controller(http.Controller):
         user = request.env["res.users"].sudo().browse(uid)
         cids = request.httprequest.cookies.get("cids", str(user.company_id.id))
         cids = [int(cid) for cid in cids.split(",")]
-        record_action = backend.get_access_action()
+        record_action = backend._get_access_action()
         url_params = {
             "model": backend._name,
             "id": backend.id,

--- a/webservice/tests/test_oauth2.py
+++ b/webservice/tests/test_oauth2.py
@@ -177,6 +177,7 @@ class TestWebServiceOauth2WebApplication(CommonWebService):
                 "oauth2_token_url": f"{cls.url}oauth2/token",
                 "oauth2_audience": cls.url,
                 "oauth2_authorization_url": f"{cls.url}/authorize",
+                "oauth2_scope": "read write",
             }
         )
         return res
@@ -192,7 +193,7 @@ class TestWebServiceOauth2WebApplication(CommonWebService):
             "target": "self",
             "url": "https://localhost.demo.odoo//authorize?response_type=code&"
             "client_id=some_client_id&"
-            f"redirect_uri={quote(self.webservice.redirect_url, safe='')}&scope=&state=",
+            f"redirect_uri={quote(self.webservice.redirect_url, safe='')}",
         }
         self.assertEqual(action["type"], expected_action["type"])
         self.assertEqual(action["target"], expected_action["target"])

--- a/webservice/tests/test_oauth2.py
+++ b/webservice/tests/test_oauth2.py
@@ -192,7 +192,7 @@ class TestWebServiceOauth2WebApplication(CommonWebService):
             "target": "self",
             "url": "https://localhost.demo.odoo//authorize?response_type=code&"
             "client_id=some_client_id&"
-            f"redirect_uri={quote(self.webservice.redirect_url, safe='')}&state=",
+            f"redirect_uri={quote(self.webservice.redirect_url, safe='')}&scope=&state=",
         }
         self.assertEqual(action["type"], expected_action["type"])
         self.assertEqual(action["target"], expected_action["target"])


### PR DESCRIPTION
Add scope param in the authorization url when using oauth2.
Fix 'webservice.backend' object has no attribute get_access_action.