### PR TITLE
[14.0] endpoint_cache: fix view inheritance

### DIFF
--- a/endpoint_cache/views/endpoint_view.xml
+++ b/endpoint_cache/views/endpoint_view.xml
@@ -7,7 +7,7 @@
         <field name="model">endpoint.mixin</field>
         <field name="inherit_id" ref="endpoint.endpoint_mixin_form_view" />
         <field name="arch" type="xml">
-          <notebook>
+          <xpath expr="//page[last()]" position="after">
             <page string="Cache">
               <group>
                 <field name="cache_policy" />
@@ -34,7 +34,7 @@ resp = Response(result, content_type="application/json", status=200)
 result = dict(response=resp)
               </pre>
             </page>
-          </notebook>
+          </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
As the endpoint.endpoint form view does not really contain any element You must use xpath to find elements in the original hierarchy.