### PR TITLE
[16.0][FIX]endpoint_route_handler: missing first sync endpoint

### DIFF
--- a/endpoint_route_handler/models/ir_http.py
+++ b/endpoint_route_handler/models/ir_http.py
@@ -67,7 +67,7 @@ class IrHttp(models.AbstractModel):
                 )
                 # routing map just initialized, store last update for this env
                 cls._endpoint_route_last_version = last_version
-            elif cls._endpoint_route_last_version < last_version:
+            elif cls._endpoint_route_last_version <= last_version:
                 _logger.info("Endpoint registry updated, reset routing map")
                 cls._routing_map = {}
                 cls._rewrite_len = {}


### PR DESCRIPTION
This PR addresses this issue https://github.com/OCA/rest-framework/issues/391 in the module `rest-framework/fastapi`

In particular I cherry-picked [this commit](https://github.com/hassan510-cmd/web-api/commit/6c86413a8a28ef178bf0819ca61b541a049d7b21) from https://github.com/hassan510-cmd/web-api

See https://github.com/OCA/rest-framework/issues/391#issuecomment-1806889270 for more details