### PR TITLE
[ADD] Implement delete method in BaseRestRequestsAdapter

### DIFF
--- a/webservice/components/request_adapter.py
+++ b/webservice/components/request_adapter.py
@@ -56,6 +56,9 @@ class BaseRestRequestsAdapter(Component):
 
     def put(self, **kwargs):
         return self._request("put", **kwargs)
+    
+    def delete(self, **kwargs):
+        return self._request("delete", **kwargs)
 
     def _get_auth(self, auth=False, **kwargs):
         if auth:


### PR DESCRIPTION
This PR adds the delete method to the BaseRestRequestsAdapter class in the webservice module.

Problem:
Currently, the adapter has methods for get, post, and put, but it's missing an implementation for DELETE. This causes an AttributeError when trying to make a DELETE call via backend.call('delete', ...).

Solution:
A delete method has been added, following the same pattern as the other HTTP methods (get, post, put). It acts as a simple wrapper around the generic _request method, which already handles the underlying logic for making HTTP requests of any type.

With this change, DELETE requests can now be performed successfully using the webservice module.