### PR TITLE
[17.0][FWD] `endpoint`: forward-port querystring params usage

### DIFF
--- a/endpoint/controllers/main.py
+++ b/endpoint/controllers/main.py
@@ -17,7 +17,7 @@ class EndpointControllerMixin:
         if not endpoint:
             raise NotFound()
         endpoint._validate_request(request)
-        result = endpoint._handle_request(request)
+        result = endpoint._handle_request(request, params=params)
         return self._handle_result(result)
 
     def _handle_result(self, result):

--- a/endpoint/controllers/main.py
+++ b/endpoint/controllers/main.py
@@ -17,7 +17,7 @@ class EndpointControllerMixin:
         if not endpoint:
             raise NotFound()
         endpoint._validate_request(request)
-        result = endpoint._handle_request(request, params=params)
+        result = endpoint._handle_request(request, querystring_params=params)
         return self._handle_result(result)
 
     def _handle_result(self, result):

--- a/endpoint/demo/endpoint_demo.xml
+++ b/endpoint/demo/endpoint_demo.xml
@@ -83,4 +83,16 @@ result = {"payload": "Method used:" + request.httprequest.method}
         </field>
     </record>
 
+    <record id="endpoint_demo_8" model="endpoint.endpoint">
+        <field name="name">Demo Endpoint 8</field>
+        <field name="route">/demo/&lt;string:param1&gt;/&lt;int:param2&gt;</field>
+        <field name="request_method">GET</field>
+        <field name="exec_mode">code</field>
+        <field name="auth_type">public</field>
+        <field name="exec_as_user_id" ref="base.user_demo" />
+        <field name="code_snippet">
+result = {"payload": querystring_params}
+        </field>
+    </record>
+
 </odoo>

--- a/endpoint/models/endpoint_mixin.py
+++ b/endpoint/models/endpoint_mixin.py
@@ -105,7 +105,7 @@ class EndpointMixin(models.AbstractModel):
             'sha3_512', 'shake_128', 'shake_256', 'blake2b',
             'blake2s', 'md5', 'new'
         * hmac: Python 'hmac' library. Use 'new' to create HMAC objects.
-        * params
+        * querystring_params
 
         Must assign a ``result`` variable, with either an instance of ``Response``,
         or a dict containiny any of the keys:
@@ -189,11 +189,11 @@ class EndpointMixin(models.AbstractModel):
                 ),
             )
 
-    def _handle_exec__code(self, request, params=None):
+    def _handle_exec__code(self, request, querystring_params=None):
         if not self._code_snippet_valued():
             return {}
         eval_ctx = self._get_code_snippet_eval_context(request)
-        eval_ctx["params"] = params or {}
+        eval_ctx["querystring_params"] = querystring_params or {}
         snippet = self.code_snippet
         safe_eval.safe_eval(snippet, eval_ctx, mode="exec", nocopy=True)
         result = eval_ctx.get("result")
@@ -241,7 +241,7 @@ class EndpointMixin(models.AbstractModel):
                 _("Missing handler for exec mode %s") % self.exec_mode
             ) from e
 
-    def _handle_request(self, request, params=None):
+    def _handle_request(self, request, querystring_params=None):
         # Switch user for the whole process
         self_with_user = self
         if self.exec_as_user_id:
@@ -249,8 +249,8 @@ class EndpointMixin(models.AbstractModel):
         handler = self_with_user._get_handler()
         try:
             # In case the handler does not support params
-            if params:
-                res = handler(request, params=params)
+            if querystring_params:
+                res = handler(request, querystring_params=querystring_params)
             else:
                 res = handler(request)
         except self._bad_request_exceptions() as orig_exec:

--- a/endpoint/models/endpoint_mixin.py
+++ b/endpoint/models/endpoint_mixin.py
@@ -105,8 +105,10 @@ class EndpointMixin(models.AbstractModel):
             'sha3_512', 'shake_128', 'shake_256', 'blake2b',
             'blake2s', 'md5', 'new'
         * hmac: Python 'hmac' library. Use 'new' to create HMAC objects.
+        * params
 
-        Must generate either an instance of ``Response`` into ``response`` var or:
+        Must assign a ``result`` variable, with either an instance of ``Response``,
+        or a dict containiny any of the keys:
 
         * payload
         * headers
@@ -187,10 +189,11 @@ class EndpointMixin(models.AbstractModel):
                 ),
             )
 
-    def _handle_exec__code(self, request):
+    def _handle_exec__code(self, request, params=None):
         if not self._code_snippet_valued():
             return {}
         eval_ctx = self._get_code_snippet_eval_context(request)
+        eval_ctx["params"] = params or {}
         snippet = self.code_snippet
         safe_eval.safe_eval(snippet, eval_ctx, mode="exec", nocopy=True)
         result = eval_ctx.get("result")
@@ -238,14 +241,18 @@ class EndpointMixin(models.AbstractModel):
                 _("Missing handler for exec mode %s") % self.exec_mode
             ) from e
 
-    def _handle_request(self, request):
+    def _handle_request(self, request, params=None):
         # Switch user for the whole process
         self_with_user = self
         if self.exec_as_user_id:
             self_with_user = self.with_user(user=self.exec_as_user_id)
         handler = self_with_user._get_handler()
         try:
-            res = handler(request)
+            # In case the handler does not support params
+            if params:
+                res = handler(request, params=params)
+            else:
+                res = handler(request)
         except self._bad_request_exceptions() as orig_exec:
             self._logger.error("_validate_request: BadRequest")
             raise werkzeug.exceptions.BadRequest() from orig_exec

--- a/endpoint/tests/test_endpoint_controller.py
+++ b/endpoint/tests/test_endpoint_controller.py
@@ -77,3 +77,7 @@ class EndpointHttpCase(HttpCase):
     def test_call7(self):
         response = self.url_open("/demo/bad_method", data="ok")
         self.assertEqual(response.status_code, 405)
+
+    def test_call8(self):
+        response = self.url_open("/demo/test/8")
+        self.assertEqual(response.json(), {"param1": "test", "param2": 8})

--- a/endpoint/tests/test_endpoint_controller.py
+++ b/endpoint/tests/test_endpoint_controller.py
@@ -79,5 +79,5 @@ class EndpointHttpCase(HttpCase):
         self.assertEqual(response.status_code, 405)
 
     def test_call8(self):
-        response = self.url_open("/demo/test/8")
-        self.assertEqual(response.json(), {"param1": "test", "param2": 8})
+        response = self.url_open("/demo/test/8?extra=1")
+        self.assertEqual(response.json(), {"param1": "test", "param2": 8, "extra": "1"})


### PR DESCRIPTION
Forward-port of https://github.com/OCA/web-api/pull/80

Also includes renaming usages of `params` to `querystring_params`