### PR TITLE
[17.0][IMP]  endpoint_route_handler: Remove redundant index on `endpoint_route_handler_tool` table

### DIFF
--- a/endpoint_route_handler/README.rst
+++ b/endpoint_route_handler/README.rst
@@ -116,31 +116,31 @@ You can see a real life example on shopfloor.app model.
 Known issues / Roadmap
 ======================
 
--  add api docs helpers
+- add api docs helpers
 
--  allow multiple HTTP methods on the same endpoint
+- allow multiple HTTP methods on the same endpoint
 
--  multiple values for route and methods
+- multiple values for route and methods
 
-      keep the same in the ui for now, later own we can imagine a
-      multi-value selection or just add text field w/ proper validation
-      and cleanup
+     keep the same in the ui for now, later own we can imagine a
+     multi-value selection or just add text field w/ proper validation
+     and cleanup
 
-      remove the route field in the table of endpoint_route
+     remove the route field in the table of endpoint_route
 
-      support a comma separated list of routes maybe support comma
-      separated list of methods use only routing.routes for generating
-      the rule sort and freeze its values to update the endpoint hash
+     support a comma separated list of routes maybe support comma
+     separated list of methods use only routing.routes for generating
+     the rule sort and freeze its values to update the endpoint hash
 
-      catch dup route exception on the sync to detect duplicated routes
-      and use the endpoint_hash to retrieve the real record (note: we
-      could store more info in the routing information which will stay
-      in the map)
+     catch dup route exception on the sync to detect duplicated routes
+     and use the endpoint_hash to retrieve the real record (note: we
+     could store more info in the routing information which will stay in
+     the map)
 
-      for customizing the rule behavior the endpoint the hook is to
-      override the registry lookup
+     for customizing the rule behavior the endpoint the hook is to
+     override the registry lookup
 
-      make EndpointRule class overridable on the registry
+     make EndpointRule class overridable on the registry
 
 NOTE in v16 we won't care anymore about odoo controller so the lookup of
 the controller can be simplified to a basic py obj that holds the
@@ -167,8 +167,8 @@ Authors
 Contributors
 ------------
 
--  Simone Orsi <simone.orsi@camptocamp.com>
--  Nguyen Minh Chien <chien@trobz.com>
+- Simone Orsi <simone.orsi@camptocamp.com>
+- Nguyen Minh Chien <chien@trobz.com>
 
 Maintainers
 -----------

--- a/endpoint_route_handler/__manifest__.py
+++ b/endpoint_route_handler/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Endpoint route handler",
     "summary": """Provide mixin and tool to generate custom endpoints on the fly.""",
-    "version": "17.0.1.0.2",
+    "version": "17.0.1.0.3",
     "license": "LGPL-3",
     "development_status": "Beta",
     "author": "Camptocamp,Odoo Community Association (OCA)",

--- a/endpoint_route_handler/migrations/17.0.1.0.3/pre-migration.py
+++ b/endpoint_route_handler/migrations/17.0.1.0.3/pre-migration.py
@@ -1,0 +1,7 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, _version):
+    # Remove redundant index on endpoint_route_handler_tool
+    env.cr.execute("DROP INDEX IF EXISTS endpoint_route_handler_tool__route_index")

--- a/endpoint_route_handler/models/endpoint_route_handler.py
+++ b/endpoint_route_handler/models/endpoint_route_handler.py
@@ -19,7 +19,6 @@ class EndpointRouteHandler(models.AbstractModel):
     name = fields.Char(required=True)
     route = fields.Char(
         required=True,
-        index=True,
         compute="_compute_route",
         inverse="_inverse_route",
         readonly=False,

--- a/endpoint_route_handler/static/description/index.html
+++ b/endpoint_route_handler/static/description/index.html
@@ -471,8 +471,8 @@ separated list of methods use only routing.routes for generating
 the rule sort and freeze its values to update the endpoint hash</p>
 <p>catch dup route exception on the sync to detect duplicated routes
 and use the endpoint_hash to retrieve the real record (note: we
-could store more info in the routing information which will stay
-in the map)</p>
+could store more info in the routing information which will stay in
+the map)</p>
 <p>for customizing the rule behavior the endpoint the hook is to
 override the registry lookup</p>
 <p>make EndpointRule class overridable on the registry</p>


### PR DESCRIPTION
We currently have two B-tree indexes on the `route` column:
1. `endpoint_route_handler_tool_endpoint_route_unique` (Unique Constraint)
2. `endpoint_route_handler_tool__route_index` (Standard Index)