### PR TITLE
[19.0][IMP] endpoint: request content schema

### DIFF
--- a/endpoint/README.rst
+++ b/endpoint/README.rst
@@ -51,12 +51,146 @@ records.
 Configuration
 =============
 
-Go to "Technical -> Endpoints" and create a new endpoint.
+Endpoints are managed under **Technical → Endpoints**.
+
+Each record represents a single HTTP route exposed by Odoo and executed
+according to its configuration.
+
+Identification
+--------------
+
+- **Name**: human-readable label used in lists and logs.
+- **Route**: URL path served by the endpoint (e.g. ``/my/custom/path``).
+  Routes must be unique across **all** endpoint-consumer models, not
+  only within ``endpoint.endpoint``.
+- **Route group**: free-text tag to classify related routes together.
+  Useful for filtering and for downstream modules that group endpoints.
+
+Authentication
+--------------
+
+- **Auth type**:
+
+  - ``User``: the request must be authenticated as an Odoo user
+    (default).
+  - ``Public``: the route is accessible without authentication.
+
+- **Exec as user**: the user under which the code snippet runs.
+
+  - **Mandatory** when *Auth type* is ``Public`` (the public user has no
+    real privileges, so the endpoint must impersonate a real user to
+    perform any meaningful work).
+  - Optional otherwise; if set, the snippet is evaluated as that user
+    instead of the caller.
+
+Request
+-------
+
+- **Request method**: ``GET``, ``POST``, ``PUT`` or ``DELETE``. Requests
+  using any other method are rejected with ``405 Method Not Allowed``.
+
+- **Request content type**: expected ``Content-Type`` of the incoming
+  request body. Mandatory for ``POST``/``PUT``. Available values:
+
+  - ``text/plain``, ``text/csv``
+  - ``application/json``
+  - ``application/xml``
+  - ``application/x-www-form-urlencoded``
+
+  When set, requests with a different ``Content-Type`` header are
+  rejected with ``415 Unsupported Media Type``.
+
+Request content schema (optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For ``POST``/``PUT`` endpoints whose content type is
+``application/json`` or ``application/xml``, an optional **Request
+Schema** tab is shown. When a schema is provided, the request body is
+validated against it before the code snippet runs; on failure, the
+request is rejected with a structured validation error
+(``RequestValidationError``).
+
+The accepted schema format depends on the content type:
+
+- **JSON** (``application/json``): a JSON Schema (Draft 2020-12). The
+  field accepts both JSON and YAML syntax — YAML is convenient when
+  authoring schemas inline.
+- **XML** (``application/xml``): an XML Schema (XSD).
+
+Example JSON Schema (YAML form):
+
+.. code:: yaml
+
+   type: object
+   required: [name, qty]
+   properties:
+     name: { type: string }
+     qty:  { type: integer, minimum: 1 }
+
+Example XSD:
+
+.. code:: xml
+
+   <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+     <xs:element name="greeting" type="xs:string"/>
+   </xs:schema>
+
+..
+
+   **Tip:** when shipping endpoints from a module, the schema can live
+   in a separate file and be loaded into the field at install time using
+   the ``file`` attribute on the data record:
+
+   .. code:: xml
+
+      <field name="request_content_schema" type="char" file="endpoint/demo/content_schema.xsd" />
+
+Execution
+---------
+
+- **Exec mode**: how the request is handled. The base module ships
+  ``Execute code``; downstream modules can register additional modes.
+
+- **Code snippet** *(when exec mode is ``code``)*: Python code evaluated
+  via ``safe_eval`` for every request. The snippet must assign a
+  ``dict`` to the ``result`` variable; it can either contain a
+  ready-made ``Response`` (under the ``response`` key) or ``payload``,
+  ``headers`` and ``status_code`` to be assembled by the framework.
+
+  Variables exposed to the snippet (see the **Code Help** tab on the
+  form for the live, up-to-date list):
+
+  - ``env``, ``user``, ``endpoint``, ``request``
+  - ``datetime``, ``dateutil``, ``time``, ``json``
+  - ``Response`` (Odoo's ``http.Response``)
+  - ``werkzeug`` (limited to ``NotFound``, ``BadRequest``,
+    ``Unauthorized``)
+  - ``exceptions`` (limited to ``UserError``, ``ValidationError``)
+  - ``hashlib``, ``hmac`` (subset of the standard library)
+  - ``log(message, level="info")`` — writes to ``ir.logging``
+
+  Raising ``UserError`` or ``ValidationError`` from the snippet is
+  converted to ``400 Bad Request``.
+
+Minimal snippet:
+
+.. code:: python
+
+   result = {"response": Response("Hello, World!")}
+
+Registry synchronization
+------------------------
+
+Endpoints are registered in a routing registry that lives outside the
+ORM. After creating, modifying or archiving a record, the warning
+*"Registry out of sync"* appears on the form, and the record is shown in
+the **To sync** filter on the list view. Run the **Sync registry**
+action to commit the changes to the live routing table — until then, the
+new configuration is **not** served.
 
 Known issues / Roadmap
 ======================
 
-- add validation of request data
 - add api docs generation
 - handle multiple routes per endpoint
 
@@ -82,6 +216,7 @@ Contributors
 ------------
 
 - Simone Orsi <simone.orsi@camptocamp.com>
+- Iván Todorovich <ivan.todorovich@camptocamp.com>
 - Alex Garcia <alex@studio73.es>
 
 Maintainers

--- a/endpoint/__manifest__.py
+++ b/endpoint/__manifest__.py
@@ -11,6 +11,9 @@
     "maintainers": ["simahawk"],
     "website": "https://github.com/OCA/web-api",
     "depends": ["endpoint_route_handler", "rpc_helper"],
+    "external_dependencies": {
+        "python": ["jsonschema", "PyYAML"],
+    },
     "data": [
         "data/server_action.xml",
         "security/ir.model.access.csv",

--- a/endpoint/exceptions.py
+++ b/endpoint/exceptions.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Camptocamp SA (https://www.camptocamp.com).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import json
+
+import werkzeug.exceptions
+import werkzeug.wrappers
+
+
+class RequestValidationError(werkzeug.exceptions.BadRequest):
+    """Bad request raised when the body fails JSON Schema validation.
+
+    Emits ``{"detail": [{"loc", "msg", "type"}, ...]}`` (FastAPI-style)
+    instead of the generic werkzeug HTML body.
+    """
+
+    def __init__(self, detail):
+        super().__init__()
+        self.detail = detail
+
+    def get_response(self, environ=None, scope=None):
+        return werkzeug.wrappers.Response(
+            json.dumps({"detail": self.detail}),
+            status=self.code,
+            mimetype="application/json",
+        )

--- a/endpoint/models/endpoint_mixin.py
+++ b/endpoint/models/endpoint_mixin.py
@@ -2,15 +2,21 @@
 # @author: Simone Orsi <simone.orsi@camptocamp.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+import json
 import textwrap
 
+import jsonschema
 import werkzeug
+import yaml
+from lxml import etree
 
 from odoo import api, exceptions, fields, http, models
 from odoo.exceptions import UserError
 from odoo.tools import safe_eval
 
 from odoo.addons.rpc_helper.decorator import disable_rpc
+
+from ..exceptions import RequestValidationError
 
 hashlib = safe_eval.wrap_module(
     __import__("hashlib"),
@@ -48,6 +54,18 @@ class EndpointMixin(models.AbstractModel):
         selection="_selection_exec_mode",
         required=True,
     )
+    request_content_schema = fields.Text(
+        help=(
+            "Optional schema validated against the parsed request body. "
+            "The accepted format depends on 'Request content type':\n"
+            " - application/json: JSON Schema (Draft 2020-12), as YAML or JSON\n"
+            " - application/xml, text/xml: XML Schema (XSD)\n"
+            "If empty, no validation runs."
+        ),
+    )
+    request_content_schema_applicable = fields.Boolean(
+        compute="_compute_request_content_schema_applicable",
+    )
     code_snippet = fields.Text()
     code_snippet_docs = fields.Text(
         compute="_compute_code_snippet_docs",
@@ -79,6 +97,69 @@ class EndpointMixin(models.AbstractModel):
                     "Exec mode is set to `Code`: you must provide a piece of code"
                 )
             )
+
+    def _get_request_content_schema_applicable_for_types(self):
+        """Content types for which ``request_content_schema`` applies."""
+        return ["application/json", "application/xml"]
+
+    @api.depends("request_method", "request_content_type")
+    def _compute_request_content_schema_applicable(self):
+        applicable_types = self._get_request_content_schema_applicable_for_types()
+        for rec in self:
+            rec.request_content_schema_applicable = (
+                rec.request_method in ("POST", "PUT")
+                and rec.request_content_type in applicable_types
+            )
+
+    @api.onchange("request_content_type")
+    def _onchange_request_content_type_clear_schema(self):
+        # The schema format depends on the content type (e.g. JSON Schema vs
+        # XSD), so it cannot survive a content type change.
+        self.request_content_schema = False
+
+    @api.constrains("request_content_schema", "request_content_type")
+    def _check_request_content_schema(self):
+        for rec in self:
+            if not rec.request_content_schema:
+                continue
+            elif rec.request_content_type == "application/json":
+                rec._check_request_content_schema_json()
+            elif rec.request_content_type == "application/xml":
+                rec._check_request_content_schema_xml()
+
+    def _check_request_content_schema_json(self):
+        try:
+            schema = yaml.safe_load(self.request_content_schema)
+        except yaml.YAMLError as exception:
+            raise UserError(
+                self.env._("Invalid YAML/JSON in request content schema: %s", exception)
+            ) from exception
+        try:
+            jsonschema.Draft202012Validator.check_schema(schema)
+        except jsonschema.SchemaError as exception:
+            raise UserError(
+                self.env._(
+                    "Invalid JSON Schema in request content schema: %s",
+                    exception.message,
+                )
+            ) from exception
+
+    def _check_request_content_schema_xml(self):
+        try:
+            schema_doc = etree.fromstring(self.request_content_schema.encode())
+        except etree.XMLSyntaxError as exception:
+            raise UserError(
+                self.env._("Invalid XML in request content schema: %s", exception)
+            ) from exception
+        try:
+            etree.XMLSchema(schema_doc)
+        except etree.XMLSchemaParseError as exception:
+            raise UserError(
+                self.env._(
+                    "Invalid XML Schema (XSD) in request content schema: %s",
+                    exception,
+                )
+            ) from exception
 
     @api.constrains("auth_type")
     def _check_auth(self):
@@ -233,6 +314,59 @@ class EndpointMixin(models.AbstractModel):
         ):
             self._logger.error("_validate_request: UnsupportedMediaType")
             raise werkzeug.exceptions.UnsupportedMediaType()
+        self._validate_request_content(request)
+
+    def _validate_request_content(self, request):
+        if not (self.request_content_schema and self.request_content_schema_applicable):
+            return
+        if self.request_content_type == "application/json":
+            self._validate_request_content_json(request)
+        elif self.request_content_type == "application/xml":
+            self._validate_request_content_xml(request)
+
+    def _validate_request_content_json(self, request):
+        try:
+            body = request.get_json_data()
+        except json.JSONDecodeError as exception:
+            self._logger.error("Invalid JSON body: %s", exception)
+            raise RequestValidationError(
+                [{"loc": ["body"], "msg": str(exception), "type": "json_invalid"}]
+            ) from exception
+        schema = yaml.safe_load(self.request_content_schema)
+        errors = list(jsonschema.Draft202012Validator(schema).iter_errors(body))
+        if errors:
+            self._logger.error("Schema validation failed (%d errors)", len(errors))
+            raise RequestValidationError(
+                [
+                    {
+                        "loc": ["body", *err.absolute_path],
+                        "msg": err.message,
+                        "type": err.validator,
+                    }
+                    for err in errors
+                ]
+            )
+
+    def _validate_request_content_xml(self, request):
+        body = request.httprequest.get_data()
+        try:
+            doc = etree.fromstring(body)
+        except etree.XMLSyntaxError as exception:
+            self._logger.error("Invalid XML body: %s", exception)
+            raise RequestValidationError(
+                [{"loc": ["body"], "msg": str(exception), "type": "xml_invalid"}]
+            ) from exception
+        schema = etree.XMLSchema(etree.fromstring(self.request_content_schema.encode()))
+        if not schema.validate(doc):
+            self._logger.error(
+                "Schema validation failed (%d errors)", len(schema.error_log)
+            )
+            raise RequestValidationError(
+                [
+                    {"loc": ["body"], "msg": err.message, "type": "xml_schema"}
+                    for err in schema.error_log
+                ]
+            )
 
     def _get_handler(self):
         try:

--- a/endpoint/readme/CONFIGURE.md
+++ b/endpoint/readme/CONFIGURE.md
@@ -1,1 +1,119 @@
-Go to "Technical -\> Endpoints" and create a new endpoint.
+Endpoints are managed under **Technical → Endpoints**.
+
+Each record represents a single HTTP route exposed by Odoo and executed
+according to its configuration.
+
+## Identification
+
+- **Name**: human-readable label used in lists and logs.
+- **Route**: URL path served by the endpoint (e.g. `/my/custom/path`).
+  Routes must be unique across **all** endpoint-consumer models, not
+  only within `endpoint.endpoint`.
+- **Route group**: free-text tag to classify related routes together.
+  Useful for filtering and for downstream modules that group endpoints.
+
+## Authentication
+
+- **Auth type**:
+  - `User`: the request must be authenticated as an Odoo user (default).
+  - `Public`: the route is accessible without authentication.
+- **Exec as user**: the user under which the code snippet runs.
+  - **Mandatory** when *Auth type* is `Public` (the public user has no
+    real privileges, so the endpoint must impersonate a real user to
+    perform any meaningful work).
+  - Optional otherwise; if set, the snippet is evaluated as that user
+    instead of the caller.
+
+## Request
+
+- **Request method**: `GET`, `POST`, `PUT` or `DELETE`. Requests using
+  any other method are rejected with `405 Method Not Allowed`.
+- **Request content type**: expected `Content-Type` of the incoming
+  request body. Mandatory for `POST`/`PUT`. Available values:
+  - `text/plain`, `text/csv`
+  - `application/json`
+  - `application/xml`
+  - `application/x-www-form-urlencoded`
+
+  When set, requests with a different `Content-Type` header are rejected
+  with `415 Unsupported Media Type`.
+
+### Request content schema (optional)
+
+For `POST`/`PUT` endpoints whose content type is `application/json` or
+`application/xml`, an optional **Request Schema** tab is shown. When a
+schema is provided, the request body is validated against it before the
+code snippet runs; on failure, the request is rejected with a structured
+validation error (`RequestValidationError`).
+
+The accepted schema format depends on the content type:
+
+- **JSON** (`application/json`): a JSON Schema (Draft 2020-12). The field
+  accepts both JSON and YAML syntax — YAML is convenient when authoring
+  schemas inline.
+- **XML** (`application/xml`): an XML Schema (XSD).
+
+Example JSON Schema (YAML form):
+
+```yaml
+type: object
+required: [name, qty]
+properties:
+  name: { type: string }
+  qty:  { type: integer, minimum: 1 }
+```
+
+Example XSD:
+
+```xml
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="greeting" type="xs:string"/>
+</xs:schema>
+```
+
+> **Tip:** when shipping endpoints from a module, the schema can live in
+> a separate file and be loaded into the field at install time using the
+> `file` attribute on the data record:
+>
+> ```xml
+> <field name="request_content_schema" type="char" file="endpoint/demo/content_schema.xsd" />
+> ```
+
+## Execution
+
+- **Exec mode**: how the request is handled. The base module ships
+  `Execute code`; downstream modules can register additional modes.
+- **Code snippet** *(when exec mode is `code`)*: Python code evaluated
+  via `safe_eval` for every request. The snippet must assign a `dict`
+  to the `result` variable; it can either contain a ready-made
+  `Response` (under the `response` key) or `payload`, `headers` and
+  `status_code` to be assembled by the framework.
+
+  Variables exposed to the snippet (see the **Code Help** tab on the
+  form for the live, up-to-date list):
+
+  - `env`, `user`, `endpoint`, `request`
+  - `datetime`, `dateutil`, `time`, `json`
+  - `Response` (Odoo's `http.Response`)
+  - `werkzeug` (limited to `NotFound`, `BadRequest`, `Unauthorized`)
+  - `exceptions` (limited to `UserError`, `ValidationError`)
+  - `hashlib`, `hmac` (subset of the standard library)
+  - `log(message, level="info")` — writes to `ir.logging`
+
+  Raising `UserError` or `ValidationError` from the snippet is converted
+  to `400 Bad Request`.
+
+Minimal snippet:
+
+```python
+result = {"response": Response("Hello, World!")}
+```
+
+## Registry synchronization
+
+Endpoints are registered in a routing registry that lives outside the
+ORM. After creating, modifying or archiving a record, the warning
+*"Registry out of sync"* appears on the form, and the record is shown in
+the **To sync** filter on the list view. Run the **Sync registry**
+action to commit the changes to the live routing table — until then, the
+new configuration is **not** served.

--- a/endpoint/readme/CONTRIBUTORS.md
+++ b/endpoint/readme/CONTRIBUTORS.md
@@ -1,2 +1,3 @@
 - Simone Orsi \<<simone.orsi@camptocamp.com>\>
+- Iván Todorovich \<<ivan.todorovich@camptocamp.com>\>
 - Alex Garcia \<<alex@studio73.es>\>

--- a/endpoint/readme/ROADMAP.md
+++ b/endpoint/readme/ROADMAP.md
@@ -1,3 +1,2 @@
-- add validation of request data
 - add api docs generation
 - handle multiple routes per endpoint

--- a/endpoint/static/description/index.html
+++ b/endpoint/static/description/index.html
@@ -385,31 +385,171 @@ records.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a><ul>
+<li><a class="reference internal" href="#identification" id="toc-entry-2">Identification</a></li>
+<li><a class="reference internal" href="#authentication" id="toc-entry-3">Authentication</a></li>
+<li><a class="reference internal" href="#request" id="toc-entry-4">Request</a><ul>
+<li><a class="reference internal" href="#request-content-schema-optional" id="toc-entry-5">Request content schema (optional)</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#execution" id="toc-entry-6">Execution</a></li>
+<li><a class="reference internal" href="#registry-synchronization" id="toc-entry-7">Registry synchronization</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-8">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-9">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-10">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-11">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-12">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-13">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="configuration">
 <h2><a class="toc-backref" href="#toc-entry-1">Configuration</a></h2>
-<p>Go to “Technical -&gt; Endpoints” and create a new endpoint.</p>
+<p>Endpoints are managed under <strong>Technical → Endpoints</strong>.</p>
+<p>Each record represents a single HTTP route exposed by Odoo and executed
+according to its configuration.</p>
+<div class="section" id="identification">
+<h3><a class="toc-backref" href="#toc-entry-2">Identification</a></h3>
+<ul class="simple">
+<li><strong>Name</strong>: human-readable label used in lists and logs.</li>
+<li><strong>Route</strong>: URL path served by the endpoint (e.g. <tt class="docutils literal">/my/custom/path</tt>).
+Routes must be unique across <strong>all</strong> endpoint-consumer models, not
+only within <tt class="docutils literal">endpoint.endpoint</tt>.</li>
+<li><strong>Route group</strong>: free-text tag to classify related routes together.
+Useful for filtering and for downstream modules that group endpoints.</li>
+</ul>
+</div>
+<div class="section" id="authentication">
+<h3><a class="toc-backref" href="#toc-entry-3">Authentication</a></h3>
+<ul class="simple">
+<li><strong>Auth type</strong>:<ul>
+<li><tt class="docutils literal">User</tt>: the request must be authenticated as an Odoo user
+(default).</li>
+<li><tt class="docutils literal">Public</tt>: the route is accessible without authentication.</li>
+</ul>
+</li>
+<li><strong>Exec as user</strong>: the user under which the code snippet runs.<ul>
+<li><strong>Mandatory</strong> when <em>Auth type</em> is <tt class="docutils literal">Public</tt> (the public user has no
+real privileges, so the endpoint must impersonate a real user to
+perform any meaningful work).</li>
+<li>Optional otherwise; if set, the snippet is evaluated as that user
+instead of the caller.</li>
+</ul>
+</li>
+</ul>
+</div>
+<div class="section" id="request">
+<h3><a class="toc-backref" href="#toc-entry-4">Request</a></h3>
+<ul>
+<li><p class="first"><strong>Request method</strong>: <tt class="docutils literal">GET</tt>, <tt class="docutils literal">POST</tt>, <tt class="docutils literal">PUT</tt> or <tt class="docutils literal">DELETE</tt>. Requests
+using any other method are rejected with <tt class="docutils literal">405 Method Not Allowed</tt>.</p>
+</li>
+<li><p class="first"><strong>Request content type</strong>: expected <tt class="docutils literal"><span class="pre">Content-Type</span></tt> of the incoming
+request body. Mandatory for <tt class="docutils literal">POST</tt>/<tt class="docutils literal">PUT</tt>. Available values:</p>
+<ul class="simple">
+<li><tt class="docutils literal">text/plain</tt>, <tt class="docutils literal">text/csv</tt></li>
+<li><tt class="docutils literal">application/json</tt></li>
+<li><tt class="docutils literal">application/xml</tt></li>
+<li><tt class="docutils literal"><span class="pre">application/x-www-form-urlencoded</span></tt></li>
+</ul>
+<p>When set, requests with a different <tt class="docutils literal"><span class="pre">Content-Type</span></tt> header are
+rejected with <tt class="docutils literal">415 Unsupported Media Type</tt>.</p>
+</li>
+</ul>
+<div class="section" id="request-content-schema-optional">
+<h4><a class="toc-backref" href="#toc-entry-5">Request content schema (optional)</a></h4>
+<p>For <tt class="docutils literal">POST</tt>/<tt class="docutils literal">PUT</tt> endpoints whose content type is
+<tt class="docutils literal">application/json</tt> or <tt class="docutils literal">application/xml</tt>, an optional <strong>Request
+Schema</strong> tab is shown. When a schema is provided, the request body is
+validated against it before the code snippet runs; on failure, the
+request is rejected with a structured validation error
+(<tt class="docutils literal">RequestValidationError</tt>).</p>
+<p>The accepted schema format depends on the content type:</p>
+<ul class="simple">
+<li><strong>JSON</strong> (<tt class="docutils literal">application/json</tt>): a JSON Schema (Draft 2020-12). The
+field accepts both JSON and YAML syntax — YAML is convenient when
+authoring schemas inline.</li>
+<li><strong>XML</strong> (<tt class="docutils literal">application/xml</tt>): an XML Schema (XSD).</li>
+</ul>
+<p>Example JSON Schema (YAML form):</p>
+<pre class="code yaml literal-block">
+<span class="nt">type</span><span class="p">:</span><span class="w"> </span><span class="l-Scalar-Plain">object</span><span class="w">
+</span><span class="nt">required</span><span class="p">:</span><span class="w"> </span><span class="p-Indicator">[</span><span class="nv">name</span><span class="p-Indicator">,</span><span class="w"> </span><span class="nv">qty</span><span class="p-Indicator">]</span><span class="w">
+</span><span class="nt">properties</span><span class="p">:</span><span class="w">
+  </span><span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="p-Indicator">{</span><span class="nt"> type</span><span class="p">:</span><span class="w"> </span><span class="nv">string</span><span class="w"> </span><span class="p-Indicator">}</span><span class="w">
+  </span><span class="nt">qty</span><span class="p">:</span><span class="w">  </span><span class="p-Indicator">{</span><span class="nt"> type</span><span class="p">:</span><span class="w"> </span><span class="nv">integer</span><span class="p-Indicator">,</span><span class="nt"> minimum</span><span class="p">:</span><span class="w"> </span><span class="nv">1</span><span class="w"> </span><span class="p-Indicator">}</span>
+</pre>
+<p>Example XSD:</p>
+<pre class="code xml literal-block">
+<span class="nt">&lt;xs:schema</span><span class="w"> </span><span class="na">xmlns:xs=</span><span class="s">&quot;http://www.w3.org/2001/XMLSchema&quot;</span><span class="nt">&gt;</span><span class="w">
+  </span><span class="nt">&lt;xs:element</span><span class="w"> </span><span class="na">name=</span><span class="s">&quot;greeting&quot;</span><span class="w"> </span><span class="na">type=</span><span class="s">&quot;xs:string&quot;</span><span class="nt">/&gt;</span><span class="w">
+</span><span class="nt">&lt;/xs:schema&gt;</span>
+</pre>
+<!--  -->
+<blockquote>
+<p><strong>Tip:</strong> when shipping endpoints from a module, the schema can live
+in a separate file and be loaded into the field at install time using
+the <tt class="docutils literal">file</tt> attribute on the data record:</p>
+<pre class="code xml literal-block">
+<span class="nt">&lt;field</span><span class="w"> </span><span class="na">name=</span><span class="s">&quot;request_content_schema&quot;</span><span class="w"> </span><span class="na">type=</span><span class="s">&quot;char&quot;</span><span class="w"> </span><span class="na">file=</span><span class="s">&quot;endpoint/demo/content_schema.xsd&quot;</span><span class="w"> </span><span class="nt">/&gt;</span>
+</pre>
+</blockquote>
+</div>
+</div>
+<div class="section" id="execution">
+<h3><a class="toc-backref" href="#toc-entry-6">Execution</a></h3>
+<ul>
+<li><p class="first"><strong>Exec mode</strong>: how the request is handled. The base module ships
+<tt class="docutils literal">Execute code</tt>; downstream modules can register additional modes.</p>
+</li>
+<li><p class="first"><strong>Code snippet</strong> <em>(when exec mode is ``code``)</em>: Python code evaluated
+via <tt class="docutils literal">safe_eval</tt> for every request. The snippet must assign a
+<tt class="docutils literal">dict</tt> to the <tt class="docutils literal">result</tt> variable; it can either contain a
+ready-made <tt class="docutils literal">Response</tt> (under the <tt class="docutils literal">response</tt> key) or <tt class="docutils literal">payload</tt>,
+<tt class="docutils literal">headers</tt> and <tt class="docutils literal">status_code</tt> to be assembled by the framework.</p>
+<p>Variables exposed to the snippet (see the <strong>Code Help</strong> tab on the
+form for the live, up-to-date list):</p>
+<ul class="simple">
+<li><tt class="docutils literal">env</tt>, <tt class="docutils literal">user</tt>, <tt class="docutils literal">endpoint</tt>, <tt class="docutils literal">request</tt></li>
+<li><tt class="docutils literal">datetime</tt>, <tt class="docutils literal">dateutil</tt>, <tt class="docutils literal">time</tt>, <tt class="docutils literal">json</tt></li>
+<li><tt class="docutils literal">Response</tt> (Odoo’s <tt class="docutils literal">http.Response</tt>)</li>
+<li><tt class="docutils literal">werkzeug</tt> (limited to <tt class="docutils literal">NotFound</tt>, <tt class="docutils literal">BadRequest</tt>,
+<tt class="docutils literal">Unauthorized</tt>)</li>
+<li><tt class="docutils literal">exceptions</tt> (limited to <tt class="docutils literal">UserError</tt>, <tt class="docutils literal">ValidationError</tt>)</li>
+<li><tt class="docutils literal">hashlib</tt>, <tt class="docutils literal">hmac</tt> (subset of the standard library)</li>
+<li><tt class="docutils literal">log(message, <span class="pre">level=&quot;info&quot;)</span></tt> — writes to <tt class="docutils literal">ir.logging</tt></li>
+</ul>
+<p>Raising <tt class="docutils literal">UserError</tt> or <tt class="docutils literal">ValidationError</tt> from the snippet is
+converted to <tt class="docutils literal">400 Bad Request</tt>.</p>
+</li>
+</ul>
+<p>Minimal snippet:</p>
+<pre class="code python literal-block">
+<span class="n">result</span> <span class="o">=</span> <span class="p">{</span><span class="s2">&quot;response&quot;</span><span class="p">:</span> <span class="n">Response</span><span class="p">(</span><span class="s2">&quot;Hello, World!&quot;</span><span class="p">)}</span>
+</pre>
+</div>
+<div class="section" id="registry-synchronization">
+<h3><a class="toc-backref" href="#toc-entry-7">Registry synchronization</a></h3>
+<p>Endpoints are registered in a routing registry that lives outside the
+ORM. After creating, modifying or archiving a record, the warning
+<em>“Registry out of sync”</em> appears on the form, and the record is shown in
+the <strong>To sync</strong> filter on the list view. Run the <strong>Sync registry</strong>
+action to commit the changes to the live routing table — until then, the
+new configuration is <strong>not</strong> served.</p>
+</div>
 </div>
 <div class="section" id="known-issues-roadmap">
-<h2><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Known issues / Roadmap</a></h2>
 <ul class="simple">
-<li>add validation of request data</li>
 <li>add api docs generation</li>
 <li>handle multiple routes per endpoint</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-9">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/web-api/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -417,22 +557,23 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-4">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-10">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-5">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-11">Authors</a></h3>
 <ul class="simple">
 <li>Camptocamp</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-6">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-12">Contributors</a></h3>
 <ul class="simple">
 <li>Simone Orsi &lt;<a class="reference external" href="mailto:simone.orsi&#64;camptocamp.com">simone.orsi&#64;camptocamp.com</a>&gt;</li>
+<li>Iván Todorovich &lt;<a class="reference external" href="mailto:ivan.todorovich&#64;camptocamp.com">ivan.todorovich&#64;camptocamp.com</a>&gt;</li>
 <li>Alex Garcia &lt;<a class="reference external" href="mailto:alex&#64;studio73.es">alex&#64;studio73.es</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-13">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/endpoint/tests/__init__.py
+++ b/endpoint/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_endpoint
+from . import test_endpoint_content_schema_validation
 from . import test_endpoint_controller

--- a/endpoint/tests/common.py
+++ b/endpoint/tests/common.py
@@ -101,6 +101,42 @@ def _setup_demo_records(env):
             ),
         }
     )
+    endpoints += env["endpoint.endpoint"].create(
+        {
+            "name": "Demo Endpoint 8",
+            "route": "/demo/schema",
+            "request_method": "POST",
+            "request_content_type": "application/json",
+            "auth_type": "public",
+            "exec_as_user_id": demo_user.id,
+            "exec_mode": "code",
+            "code_snippet": 'result = {"payload": {"ok": True}}',
+            "request_content_schema": (
+                "type: object\n"
+                "required: [data]\n"
+                "properties:\n"
+                "  data:\n"
+                "    type: array\n"
+            ),
+        }
+    )
+    endpoints += env["endpoint.endpoint"].create(
+        {
+            "name": "Demo Endpoint 9",
+            "route": "/demo/schema-xml",
+            "request_method": "POST",
+            "request_content_type": "application/xml",
+            "auth_type": "public",
+            "exec_as_user_id": demo_user.id,
+            "exec_mode": "code",
+            "code_snippet": 'result = {"payload": {"ok": True}}',
+            "request_content_schema": (
+                '<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">'
+                '<xs:element name="greeting" type="xs:string"/>'
+                "</xs:schema>"
+            ),
+        }
+    )
     return endpoints
 
 

--- a/endpoint/tests/test_endpoint_content_schema_validation.py
+++ b/endpoint/tests/test_endpoint_content_schema_validation.py
@@ -1,0 +1,195 @@
+# Copyright 2026 Camptocamp SA
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import json
+import os
+from unittest import mock, skipIf
+
+from odoo import exceptions
+from odoo.tests import Form, HttpCase
+from odoo.tools.misc import mute_logger
+
+from .common import CommonEndpoint, _setup_demo_records
+
+
+class TestEndpointContentSchemaValidation(CommonEndpoint):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.endpoint_json = cls.env["endpoint.endpoint"].search(
+            [("route", "=", "/demo/schema")]
+        )
+        cls.endpoint_xml = cls.env["endpoint.endpoint"].search(
+            [("route", "=", "/demo/schema-xml")]
+        )
+
+    def test_request_content_schema_applicable_post_json(self):
+        self.assertTrue(self.endpoint_json.request_content_schema_applicable)
+
+    def test_request_content_schema_applicable_put_json(self):
+        self.endpoint_json.request_method = "PUT"
+        self.assertTrue(self.endpoint_json.request_content_schema_applicable)
+
+    def test_request_content_schema_applicable_post_xml(self):
+        self.assertTrue(self.endpoint_xml.request_content_schema_applicable)
+
+    def test_request_content_schema_not_applicable_for_non_body_method(self):
+        self.endpoint_json.write(
+            {"request_method": "GET", "request_content_type": False}
+        )
+        self.assertFalse(self.endpoint_json.request_content_schema_applicable)
+
+    def test_request_content_schema_not_applicable_for_unsupported_type(self):
+        # Clear the schema first; otherwise the constraint would re-validate
+        # the JSON Schema content as if it were the new (non-applicable) type.
+        self.endpoint_json.request_content_schema = False
+        self.endpoint_json.request_content_type = "text/plain"
+        self.assertFalse(self.endpoint_json.request_content_schema_applicable)
+
+    def test_request_content_schema_cleared_on_content_type_change(self):
+        self.assertTrue(self.endpoint_json.request_content_schema)
+        # Minimal view to bypass form inheritance from sibling modules that
+        # may not be loaded when the endpoint module is tested in isolation.
+        with Form(self.endpoint_json) as form:
+            form.request_content_type = "application/xml"
+            self.assertFalse(form.request_content_schema)
+
+    def test_request_content_schema_invalid_yaml_raises(self):
+        with self.assertRaisesRegex(
+            exceptions.UserError, r"Invalid YAML/JSON in request content schema"
+        ):
+            self.endpoint_json.request_content_schema = "this: is: not: valid: yaml: ["
+
+    def test_request_content_schema_invalid_jsonschema_raises(self):
+        with self.assertRaisesRegex(
+            exceptions.UserError, r"Invalid JSON Schema in request content schema"
+        ):
+            self.endpoint_json.request_content_schema = "type: not_a_real_type"
+
+    def test_request_content_schema_valid_json_ok(self):
+        self.endpoint_json.request_content_schema = json.dumps(
+            {"type": "object", "required": ["data"]}
+        )
+
+    def test_request_content_schema_valid_xsd_ok(self):
+        self.endpoint_xml.request_content_schema = (
+            '<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">'
+            '<xs:element name="root" type="xs:string"/>'
+            "</xs:schema>"
+        )
+
+    def test_request_content_schema_invalid_xml_raises(self):
+        with self.assertRaisesRegex(
+            exceptions.UserError, r"Invalid XML in request content schema"
+        ):
+            self.endpoint_xml.request_content_schema = "<not-valid-xml"
+
+    def test_request_content_schema_invalid_xsd_raises(self):
+        with self.assertRaisesRegex(
+            exceptions.UserError, r"Invalid XML Schema \(XSD\)"
+        ):
+            self.endpoint_xml.request_content_schema = (
+                '<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">'
+                '<xs:element name="root" type="xs:nonExistentType"/>'
+                "</xs:schema>"
+            )
+
+    def test_request_content_schema_unknown_content_type_skipped(self):
+        # text/plain is not in the applicable types; the constraint dispatch
+        # is a no-op and any text passes.
+        self.endpoint_json.request_content_type = "text/plain"
+        self.endpoint_json.request_content_schema = "this is not JSON or XML"
+        self.assertTrue(self.endpoint_json.request_content_schema)
+
+    def test_validate_request_content_skipped_without_schema(self):
+        self.endpoint_json.request_content_schema = False
+        get_json_data = mock.Mock()
+        with self._get_mocked_request(httprequest={"method": "POST"}) as req:
+            req.get_json_data = get_json_data
+            self.endpoint_json._validate_request_content(req)
+        get_json_data.assert_not_called()
+
+    def test_validate_request_content_skipped_for_non_applicable_type(self):
+        self.endpoint_json.request_content_type = "text/plain"
+        get_json_data = mock.Mock()
+        with self._get_mocked_request(httprequest={"method": "POST"}) as req:
+            req.get_json_data = get_json_data
+            self.endpoint_json._validate_request_content(req)
+        get_json_data.assert_not_called()
+
+
+@skipIf(os.getenv("SKIP_HTTP_CASE"), "HttpCase skipped")
+class TestEndpointContentSchemaValidationHttp(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _setup_demo_records(cls.env)
+        cls.env["endpoint.endpoint"].search([])._handle_registry_sync()
+
+    def tearDown(self):
+        # Clear cache for method ``ir.http.routing_map()``
+        self.env.registry.clear_cache("routing")
+        super().tearDown()
+
+    def test_json_valid_body(self):
+        response = self.url_open(
+            "/demo/schema",
+            data=json.dumps({"data": [1, 2, 3]}),
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content.decode()), {"ok": True})
+
+    @mute_logger("endpoint.endpoint")
+    def test_json_invalid_body(self):
+        response = self.url_open(
+            "/demo/schema",
+            data=json.dumps({"data": "not-an-array"}),
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertEqual(response.status_code, 400)
+        payload = json.loads(response.content.decode())
+        self.assertEqual(payload["detail"][0]["loc"], ["body", "data"])
+        self.assertEqual(payload["detail"][0]["type"], "type")
+
+    @mute_logger("endpoint.endpoint")
+    def test_json_malformed_body(self):
+        response = self.url_open(
+            "/demo/schema",
+            data="not-json",
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertEqual(response.status_code, 400)
+        payload = json.loads(response.content.decode())
+        self.assertEqual(payload["detail"][0]["type"], "json_invalid")
+
+    def test_xml_valid_body(self):
+        response = self.url_open(
+            "/demo/schema-xml",
+            data=b"<greeting>hello</greeting>",
+            headers={"Content-Type": "application/xml"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content.decode()), {"ok": True})
+
+    @mute_logger("endpoint.endpoint")
+    def test_xml_invalid_body(self):
+        response = self.url_open(
+            "/demo/schema-xml",
+            data=b"<unexpected>oops</unexpected>",
+            headers={"Content-Type": "application/xml"},
+        )
+        self.assertEqual(response.status_code, 400)
+        payload = json.loads(response.content.decode())
+        self.assertEqual(payload["detail"][0]["type"], "xml_schema")
+
+    @mute_logger("endpoint.endpoint")
+    def test_xml_malformed_body(self):
+        response = self.url_open(
+            "/demo/schema-xml",
+            data=b"not-xml",
+            headers={"Content-Type": "application/xml"},
+        )
+        self.assertEqual(response.status_code, 400)
+        payload = json.loads(response.content.decode())
+        self.assertEqual(payload["detail"][0]["type"], "xml_invalid")

--- a/endpoint/views/endpoint_view.xml
+++ b/endpoint/views/endpoint_view.xml
@@ -70,6 +70,17 @@
                                 </group>
                             </group>
                         </page>
+                        <page
+                            name="request_content_schema"
+                            string="Request Schema"
+                            invisible="not request_content_schema_applicable"
+                        >
+                            <field
+                                name="request_content_schema"
+                                widget="ace"
+                                placeholder="Optional schema (JSON Schema or XSD, depending on Request Content Type)"
+                            />
+                        </page>
                         <page name="code" string="Code" invisible="exec_mode != 'code'">
                             <field name="code_snippet" widget="ace" />
                         </page>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 # generated from manifests external_dependencies
+PyYAML
+jsonschema
 oauthlib
 requests-oauthlib
 responses


### PR DESCRIPTION
Implement request content validation through an optional schema.

For `application/json`, we use the JSON Schema (same than openapi)
For `application/xml`, we use XSD Schema