### PR TITLE
[18.0] endpoint: fix lambda

### DIFF
--- a/endpoint/models/endpoint_mixin.py
+++ b/endpoint/models/endpoint_mixin.py
@@ -69,7 +69,7 @@ class EndpointMixin(models.AbstractModel):
             rec._validate_exec_mode()
 
     def _validate_exec_mode(self):
-        validator = getattr(self, "_validate_exec__" + self.exec_mode, lambda x: True)
+        validator = getattr(self, "_validate_exec__" + self.exec_mode, lambda: True)
         validator()
 
     def _validate_exec__code(self):


### PR DESCRIPTION
Backport from the 19.0 migration