### PR TITLE
[19.0][IMP] endpoint_route_handler: add bearer auth type

### DIFF
--- a/endpoint_route_handler/README.rst
+++ b/endpoint_route_handler/README.rst
@@ -95,6 +95,13 @@ instance:
    new_route = route_handler.new(vals)
    new_route._register_controller()
 
+Available ``auth_type`` values:
+
+-  ``public``: no authentication required
+-  ``user_endpoint``: session-based user authentication (default)
+-  ``bearer``: API key authentication via ``Authorization: Bearer``
+   header (uses Odoo's built-in ``res.users.apikeys``)
+
 You can override options and define - for instance - a different
 controller method:
 
@@ -120,31 +127,31 @@ You can see a real life example on shopfloor.app model.
 Known issues / Roadmap
 ======================
 
-- add api docs helpers
+-  add api docs helpers
 
-- allow multiple HTTP methods on the same endpoint
+-  allow multiple HTTP methods on the same endpoint
 
-- multiple values for route and methods
+-  multiple values for route and methods
 
-     keep the same in the ui for now, later own we can imagine a
-     multi-value selection or just add text field w/ proper validation
-     and cleanup
+      keep the same in the ui for now, later own we can imagine a
+      multi-value selection or just add text field w/ proper validation
+      and cleanup
 
-     remove the route field in the table of endpoint_route
+      remove the route field in the table of endpoint_route
 
-     support a comma separated list of routes maybe support comma
-     separated list of methods use only routing.routes for generating
-     the rule sort and freeze its values to update the endpoint hash
+      support a comma separated list of routes maybe support comma
+      separated list of methods use only routing.routes for generating
+      the rule sort and freeze its values to update the endpoint hash
 
-     catch dup route exception on the sync to detect duplicated routes
-     and use the endpoint_hash to retrieve the real record (note: we
-     could store more info in the routing information which will stay in
-     the map)
+      catch dup route exception on the sync to detect duplicated routes
+      and use the endpoint_hash to retrieve the real record (note: we
+      could store more info in the routing information which will stay
+      in the map)
 
-     for customizing the rule behavior the endpoint the hook is to
-     override the registry lookup
+      for customizing the rule behavior the endpoint the hook is to
+      override the registry lookup
 
-     make EndpointRule class overridable on the registry
+      make EndpointRule class overridable on the registry
 
 NOTE in v16 we won't care anymore about odoo controller so the lookup of
 the controller can be simplified to a basic py obj that holds the
@@ -171,8 +178,8 @@ Authors
 Contributors
 ------------
 
-- Simone Orsi <simone.orsi@camptocamp.com>
-- Nguyen Minh Chien <chien@trobz.com>
+-  Simone Orsi <simone.orsi@camptocamp.com>
+-  Nguyen Minh Chien <chien@trobz.com>
 
 Maintainers
 -----------

--- a/endpoint_route_handler/models/endpoint_route_handler.py
+++ b/endpoint_route_handler/models/endpoint_route_handler.py
@@ -109,7 +109,11 @@ class EndpointRouteHandler(models.AbstractModel):
         return [("http", "HTTP"), ("json", "JSON")]
 
     def _selection_auth_type(self):
-        return [("public", "Public"), ("user_endpoint", "User")]
+        return [
+            ("public", "Public"),
+            ("user_endpoint", "User"),
+            ("bearer", "API Key (User)"),
+        ]
 
     def _selection_request_method(self):
         return [

--- a/endpoint_route_handler/readme/USAGE.md
+++ b/endpoint_route_handler/readme/USAGE.md
@@ -40,6 +40,13 @@ instance:
     new_route = route_handler.new(vals)
     new_route._register_controller()
 
+Available `auth_type` values:
+
+- `public`: no authentication required
+- `user_endpoint`: session-based user authentication (default)
+- `bearer`: API key authentication via `Authorization: Bearer` header
+  (uses Odoo's built-in `res.users.apikeys`)
+
 You can override options and define - for instance - a different
 controller method:
 

--- a/endpoint_route_handler/static/description/index.html
+++ b/endpoint_route_handler/static/description/index.html
@@ -439,6 +439,13 @@ vals = {
 new_route = route_handler.new(vals)
 new_route._register_controller()
 </pre>
+<p>Available <tt class="docutils literal">auth_type</tt> values:</p>
+<ul class="simple">
+<li><tt class="docutils literal">public</tt>: no authentication required</li>
+<li><tt class="docutils literal">user_endpoint</tt>: session-based user authentication (default)</li>
+<li><tt class="docutils literal">bearer</tt>: API key authentication via <tt class="docutils literal">Authorization: Bearer</tt>
+header (uses Odoo’s built-in <tt class="docutils literal">res.users.apikeys</tt>)</li>
+</ul>
 <p>You can override options and define - for instance - a different
 controller method:</p>
 <pre class="literal-block">
@@ -476,8 +483,8 @@ separated list of methods use only routing.routes for generating
 the rule sort and freeze its values to update the endpoint hash</p>
 <p>catch dup route exception on the sync to detect duplicated routes
 and use the endpoint_hash to retrieve the real record (note: we
-could store more info in the routing information which will stay in
-the map)</p>
+could store more info in the routing information which will stay
+in the map)</p>
 <p>for customizing the rule behavior the endpoint the hook is to
 override the registry lookup</p>
 <p>make EndpointRule class overridable on the registry</p>

--- a/endpoint_route_handler/tests/test_endpoint.py
+++ b/endpoint_route_handler/tests/test_endpoint.py
@@ -50,6 +50,12 @@ class TestEndpoint(CommonEndpoint):
         new_route.route += "/new"
         self.assertNotEqual(new_route.endpoint_hash, first_hash)
 
+    def test_auth_type_routing_info(self):
+        for auth_type in ("public", "user_endpoint", "bearer"):
+            new_route = make_new_route(self.env, auth_type=auth_type)
+            __, routing, __ = new_route._get_routing_info()
+            self.assertEqual(routing["auth"], auth_type)
+
     @mute_logger("odoo.addons.base.models.ir_http")
     def test_as_tool_register_single_controller(self):
         new_route = make_new_route(self.env)


### PR DESCRIPTION
Add bearer to the auth_type selection so endpoints can use Odoo's native API key authentication (res.users.apikeys) without requiring an extra auth module.

@qrtl QT6769
