### PR TITLE
[19.0][FIX] endpoint_route_handler: precompute=True on route field

### DIFF
--- a/endpoint_route_handler/models/endpoint_route_handler.py
+++ b/endpoint_route_handler/models/endpoint_route_handler.py
@@ -22,6 +22,7 @@ class EndpointRouteHandler(models.AbstractModel):
         index=True,
         compute="_compute_route",
         inverse="_inverse_route",
+        precompute=True,
         readonly=False,
         store=True,
         copy=False,

--- a/endpoint_route_handler/tests/test_endpoint.py
+++ b/endpoint_route_handler/tests/test_endpoint.py
@@ -2,6 +2,7 @@
 # @author: Simone Orsi <simone.orsi@camptocamp.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from contextlib import contextmanager
+from unittest.mock import patch
 
 from odoo import api, modules
 from odoo.tests import common
@@ -49,6 +50,27 @@ class TestEndpoint(CommonEndpoint):
         self.assertTrue(first_hash)
         new_route.route += "/new"
         self.assertNotEqual(new_route.endpoint_hash, first_hash)
+
+    def test_route_field_precomputed(self):
+        """Regression guard: ensure ``precompute=True`` stays on ``route``.
+
+        Without it, downstream modules that derive ``route`` via compute
+        would hit a "Missing required value" error at INSERT time.
+        """
+        Model = type(self.env["endpoint.route.handler.tool"])
+
+        def _fake_compute_route(self):
+            for rec in self:
+                rec.route = "/precompute/probe"
+
+        with patch.object(Model, "_compute_route", _fake_compute_route):
+            rec = self.env["endpoint.route.handler.tool"].create(
+                {
+                    "name": "Precompute test",
+                    "request_method": "GET",
+                }
+            )
+            self.assertEqual(rec.route, "/precompute/probe")
 
     @mute_logger("odoo.addons.base.models.ir_http")
     def test_as_tool_register_single_controller(self):


### PR DESCRIPTION
Related: https://github.com/OCA/web-api/pull/135

Without precompute, the required computed field is evaluated after INSERT (during flush), so creating an endpoint whose route is derived from other fields by a downstream module fails with "Missing required value for the field 'Route'" — the INSERT runs before the compute can populate the column.

@qrtl QT6769