### PR TITLE
[19.0][FIX] webservice: allow to return response object on OAuth2-configure…

### DIFF
--- a/webservice/components/request_adapter.py
+++ b/webservice/components/request_adapter.py
@@ -179,6 +179,7 @@ class BackendApplicationOAuth2RestRequestsAdapter(Component):
 
     def _request(self, method, url=None, url_params=None, **kwargs):
         url = self._get_url(url=url, url_params=url_params)
+        content_only = kwargs.pop("content_only", True)
         new_kwargs = kwargs.copy()
         new_kwargs.update(
             {
@@ -191,7 +192,9 @@ class BackendApplicationOAuth2RestRequestsAdapter(Component):
             # pylint: disable=E8106
             request = session.request(method, url, **new_kwargs)
             request.raise_for_status()
-            return request.content
+            if content_only:
+                return request.content
+            return request
 
 
 class WebApplicationOAuth2RestRequestsAdapter(Component):

--- a/webservice/tests/test_oauth2.py
+++ b/webservice/tests/test_oauth2.py
@@ -148,6 +148,33 @@ class TestWebServiceOauth2BackendApplication(CommonWebService):
             "old_token",
         )
 
+    @responses.activate
+    def test_call_with_content_only_false_returns_response(self):
+        now = time.time()
+        duration = 3600
+        responses.add(
+            responses.POST,
+            f"{self.url}oauth2/token",
+            json={
+                "access_token": "cool_token",
+                "token_type": "Bearer",
+                "expires_in": duration,
+                "expires_at": now + duration,
+            },
+        )
+        responses.add(responses.POST, f"{self.url}endpoint", json={"ok": True})
+
+        with mock_cursor(self.env.cr):
+            response = self.webservice.call(
+                "post",
+                url=f"{self.url}endpoint",
+                data="payload",
+                content_only=False,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"ok": True})
+
 
 class TestWebServiceOauth2WebApplication(CommonWebService):
     @classmethod


### PR DESCRIPTION
…d calls

When sending exchanges through an OAuth2-configured webservice.backend, the request crashed with:

`TypeError: Session.request() got an unexpected keyword argument 'content_only'
`

Stack trace pointed to webservice/components/request_adapter.py in BackendApplicationOAuth2RestRequestsAdapter._request, where content_only was forwarded to OAuth2Session.request(...)

Also check https://github.com/OCA/web-api/pull/48

-----

**However** / **Open Concern**

[Defaulting content_only to True in "base.requests"](https://github.com/OCA/web-api/blob/18.0/webservice/components/request_adapter.py#L29) seems wrong IMHO (current PR follows the same pattern)

`content_only = kwargs.pop("content_only", True)
`

The function returns two entirely different data types depending on a boolean flag. If content_only is True, it returns a bytes object (request.content). If content_only is False, it returns a requests.Response object (request).

Because it defaults to True, a standard call to an endpoint `self._request("GET", "/test") `returns raw bytes instead of a typical HTTP response object. To access network metadata (such as headers or cookies), the caller must explicitly pass content_only=False. This violates the Principle of Least Astonishment.

**Open question** :warning: 
Should we keep the current compatibility contract for now (defaulting to bytes)? In this addon, the default behavior has historically been “bytes content”, and existing tests + doc. assert this.

Wanting raw content as the "normal" case and wanting the actual HTTP Response object as a "special context." is strange, but I don't have the full context in here. In global network programming, a Response object is the baseline rule :thinking:  

> All of Requests’ functionality can be accessed by these 7 methods. They all return an instance of the [Response](https://requests.readthedocs.io/en/latest/api/#requests.Response) object.

https://requests.readthedocs.io/en/latest/api/#main-interface