### PR TITLE
[19.0] [IMP] webservice: configurable OAuth2 token request

### DIFF
--- a/webservice/README.rst
+++ b/webservice/README.rst
@@ -43,6 +43,47 @@ HTTP call returns by default the content of the response. A context
 .. contents::
    :local:
 
+Configuration
+=============
+
+OAuth2 (Client Credentials)
+---------------------------
+
+For the *Backend Application (Client Credentials Grant)* flow, two extra
+options control how the token is requested, so that endpoints which
+deviate from the OAuth2 spec can still be used:
+
+- **Token Request Method**: ``POST`` (default) or ``GET``. Most
+  providers expose the token endpoint as a POST; some require a GET.
+- **Client Authentication**: how the client credentials are presented to
+  the token endpoint:
+
+  - *Client ID & Secret (HTTP Basic)* (default): the client id and
+    secret are sent as an
+    ``Authorization: Basic base64(client_id:client_secret)`` header
+    (``client_secret_basic``).
+  - *Custom Authorization header*: a static header value is sent
+    verbatim. The **Client Auth Header** (default ``Authorization``) and
+    **Client Auth Header Value** are configured directly; the Client ID
+    / Client Secret fields are not used in this case.
+
+Example: custom Authorization header
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some providers require the credentials in a non-standard Authorization
+header (for instance Okta uses ``Authorization: SSWS <token>``). Such an
+endpoint can be configured as:
+
+::
+
+   Auth Type             = OAuth2
+   OAuth2 Flow           = Backend Application (Client Credentials Grant)
+   Token URL             = https://provider.example.com/oauth2/token
+   Token Request Method  = GET
+   Client Authentication = Custom Authorization header
+   Client Auth Header    = Authorization
+   Client Auth Value     = SSWS <token>
+
 Bug Tracker
 ===========
 

--- a/webservice/components/request_adapter.py
+++ b/webservice/components/request_adapter.py
@@ -13,7 +13,7 @@ from requests_oauthlib import OAuth2Session
 
 from odoo.addons.component.core import Component
 
-from ..utils import sanitize_url_for_log
+from ..utils import StaticHeaderAuth, sanitize_url_for_log
 
 _logger = logging.getLogger(__name__)
 
@@ -160,22 +160,49 @@ class BackendApplicationOAuth2RestRequestsAdapter(Component):
         # be used (and use it in that case)
         oauth_params = self.collection.sudo().read(
             [
+                "oauth2_client_auth_method",
                 "oauth2_clientid",
                 "oauth2_client_secret",
+                "oauth2_client_auth_header",
+                "oauth2_client_auth_value",
                 "oauth2_token_url",
+                "oauth2_token_method",
                 "oauth2_audience",
                 "redirect_url",
             ]
         )[0]
         client = self.get_client(oauth_params)
         with OAuth2Session(client=client) as session:
-            token = session.fetch_token(
-                token_url=oauth_params["oauth2_token_url"],
-                client_id=oauth_params["oauth2_clientid"],
-                client_secret=oauth_params["oauth2_client_secret"],
-                audience=oauth_params.get("oauth2_audience") or "",
-            )
+            token = session.fetch_token(**self._token_fetch_kwargs(oauth_params))
         return token
+
+    def _token_fetch_kwargs(self, oauth_params):
+        """Build the ``OAuth2Session.fetch_token`` keyword arguments.
+
+        Both the HTTP method used for the token request and the way the client
+        credentials are presented to the token endpoint depend on the backend
+        configuration, so that non fully spec-compliant endpoints can be used.
+        """
+        kwargs = {
+            "method": oauth_params["oauth2_token_method"].upper(),
+            "token_url": oauth_params["oauth2_token_url"],
+            "audience": oauth_params.get("oauth2_audience") or "",
+        }
+        match oauth_params["oauth2_client_auth_method"]:
+            case "client_secret_basic":
+                kwargs["client_id"] = oauth_params["oauth2_clientid"]
+                kwargs["client_secret"] = oauth_params["oauth2_client_secret"]
+            case "custom_header":
+                kwargs["auth"] = StaticHeaderAuth(
+                    oauth_params["oauth2_client_auth_header"],
+                    oauth_params["oauth2_client_auth_value"],
+                )
+            case _:
+                raise ValueError(
+                    "Unsupported OAuth2 client authentication method: "
+                    f"{oauth_params['oauth2_client_auth_method']!r}"
+                )
+        return kwargs
 
     def _request(self, method, url=None, url_params=None, **kwargs):
         url = self._get_url(url=url, url_params=url_params)

--- a/webservice/models/webservice_backend.py
+++ b/webservice/models/webservice_backend.py
@@ -40,9 +40,37 @@ class WebserviceBackend(models.Model):
         ],
         readonly=False,
     )
-    oauth2_clientid = fields.Char(string="Client ID", auth_type="oauth2")
-    oauth2_client_secret = fields.Char(string="Client Secret", auth_type="oauth2")
+    oauth2_client_auth_method = fields.Selection(
+        [
+            ("client_secret_basic", "Client ID & Secret (HTTP Basic)"),
+            ("custom_header", "Custom Authorization header"),
+        ],
+        default="client_secret_basic",
+        string="Client Authentication",
+        help="How the client credentials are presented to the token endpoint.",
+    )
+    oauth2_clientid = fields.Char(string="Client ID")
+    oauth2_client_secret = fields.Char(string="Client Secret")
+    oauth2_client_auth_header = fields.Char(
+        string="Client Auth Header",
+        default="Authorization",
+        help="Header name used to send the client credentials when the client "
+        "authentication method is a custom Authorization header.",
+    )
+    oauth2_client_auth_value = fields.Char(
+        string="Client Auth Header Value",
+        help="Full, static header value sent to the token endpoint when the "
+        "client authentication method is a custom Authorization header "
+        "(e.g. 'SSWS <token>').",
+    )
     oauth2_token_url = fields.Char(string="Token URL", auth_type="oauth2")
+    oauth2_token_method = fields.Selection(
+        [("post", "POST"), ("get", "GET")],
+        default="post",
+        string="Token Request Method",
+        help="HTTP method used to request the token from the token endpoint. "
+        "Most providers use POST; some expose the token endpoint as GET.",
+    )
     oauth2_authorization_url = fields.Char(string="Authorization URL")
     oauth2_audience = fields.Char(
         string="Audience"
@@ -80,6 +108,46 @@ class WebserviceBackend(models.Model):
             for _field in _fields:
                 if not rec[_field.name]:
                     missing.append(_field)
+            if missing:
+                raise exceptions.UserError(rec._msg_missing_auth_param(missing))
+
+    @api.constrains(
+        "auth_type",
+        "oauth2_client_auth_method",
+        "oauth2_clientid",
+        "oauth2_client_secret",
+    )
+    def _check_oauth2_client_secret_basic(self):
+        for rec in self:
+            if rec.auth_type != "oauth2":
+                continue
+            if rec.oauth2_client_auth_method != "client_secret_basic":
+                continue
+            missing = [
+                rec._fields[fname]
+                for fname in ("oauth2_clientid", "oauth2_client_secret")
+                if not rec[fname]
+            ]
+            if missing:
+                raise exceptions.UserError(rec._msg_missing_auth_param(missing))
+
+    @api.constrains(
+        "auth_type",
+        "oauth2_client_auth_method",
+        "oauth2_client_auth_header",
+        "oauth2_client_auth_value",
+    )
+    def _check_oauth2_custom_header(self):
+        for rec in self:
+            if rec.auth_type != "oauth2":
+                continue
+            if rec.oauth2_client_auth_method != "custom_header":
+                continue
+            missing = [
+                rec._fields[fname]
+                for fname in ("oauth2_client_auth_header", "oauth2_client_auth_value")
+                if not rec[fname]
+            ]
             if missing:
                 raise exceptions.UserError(rec._msg_missing_auth_param(missing))
 

--- a/webservice/readme/CONFIGURE.md
+++ b/webservice/readme/CONFIGURE.md
@@ -1,0 +1,31 @@
+## OAuth2 (Client Credentials)
+
+For the *Backend Application (Client Credentials Grant)* flow, two extra options
+control how the token is requested, so that endpoints which deviate from the
+OAuth2 spec can still be used:
+
+- **Token Request Method**: `POST` (default) or `GET`. Most providers expose the
+  token endpoint as a POST; some require a GET.
+- **Client Authentication**: how the client credentials are presented to the
+  token endpoint:
+  - *Client ID & Secret (HTTP Basic)* (default): the client id and secret are
+    sent as an `Authorization: Basic base64(client_id:client_secret)` header
+    (`client_secret_basic`).
+  - *Custom Authorization header*: a static header value is sent verbatim. The
+    **Client Auth Header** (default `Authorization`) and **Client Auth Header
+    Value** are configured directly; the Client ID / Client Secret fields are
+    not used in this case.
+
+### Example: custom Authorization header
+
+Some providers require the credentials in a non-standard Authorization header
+(for instance Okta uses `Authorization: SSWS <token>`). Such an endpoint can be
+configured as:
+
+    Auth Type             = OAuth2
+    OAuth2 Flow           = Backend Application (Client Credentials Grant)
+    Token URL             = https://provider.example.com/oauth2/token
+    Token Request Method  = GET
+    Client Authentication = Custom Authorization header
+    Client Auth Header    = Authorization
+    Client Auth Value     = SSWS <token>

--- a/webservice/static/description/index.html
+++ b/webservice/static/description/index.html
@@ -382,17 +382,64 @@ HTTP call returns by default the content of the response. A context
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-4">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-5">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a><ul>
+<li><a class="reference internal" href="#oauth2-client-credentials" id="toc-entry-2">OAuth2 (Client Credentials)</a><ul>
+<li><a class="reference internal" href="#example-custom-authorization-header" id="toc-entry-3">Example: custom Authorization header</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h2><a class="toc-backref" href="#toc-entry-1">Configuration</a></h2>
+<div class="section" id="oauth2-client-credentials">
+<h3><a class="toc-backref" href="#toc-entry-2">OAuth2 (Client Credentials)</a></h3>
+<p>For the <em>Backend Application (Client Credentials Grant)</em> flow, two extra
+options control how the token is requested, so that endpoints which
+deviate from the OAuth2 spec can still be used:</p>
+<ul class="simple">
+<li><strong>Token Request Method</strong>: <tt class="docutils literal">POST</tt> (default) or <tt class="docutils literal">GET</tt>. Most
+providers expose the token endpoint as a POST; some require a GET.</li>
+<li><strong>Client Authentication</strong>: how the client credentials are presented to
+the token endpoint:<ul>
+<li><em>Client ID &amp; Secret (HTTP Basic)</em> (default): the client id and
+secret are sent as an
+<tt class="docutils literal">Authorization: Basic base64(client_id:client_secret)</tt> header
+(<tt class="docutils literal">client_secret_basic</tt>).</li>
+<li><em>Custom Authorization header</em>: a static header value is sent
+verbatim. The <strong>Client Auth Header</strong> (default <tt class="docutils literal">Authorization</tt>) and
+<strong>Client Auth Header Value</strong> are configured directly; the Client ID
+/ Client Secret fields are not used in this case.</li>
+</ul>
+</li>
+</ul>
+<div class="section" id="example-custom-authorization-header">
+<h4><a class="toc-backref" href="#toc-entry-3">Example: custom Authorization header</a></h4>
+<p>Some providers require the credentials in a non-standard Authorization
+header (for instance Okta uses <tt class="docutils literal">Authorization: SSWS &lt;token&gt;</tt>). Such an
+endpoint can be configured as:</p>
+<pre class="literal-block">
+Auth Type             = OAuth2
+OAuth2 Flow           = Backend Application (Client Credentials Grant)
+Token URL             = https://provider.example.com/oauth2/token
+Token Request Method  = GET
+Client Authentication = Custom Authorization header
+Client Auth Header    = Authorization
+Client Auth Value     = SSWS &lt;token&gt;
+</pre>
+</div>
+</div>
+</div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/web-api/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -400,23 +447,23 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-2">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-3">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-6">Authors</a></h3>
 <ul class="simple">
 <li>Creu Blanca</li>
 <li>Camptocamp</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-4">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-7">Contributors</a></h3>
 <ul class="simple">
 <li>Enric Tobella &lt;<a class="reference external" href="mailto:etobella&#64;creublanca.es">etobella&#64;creublanca.es</a>&gt;</li>
 <li>Alexandre Fayolle &lt;<a class="reference external" href="mailto:alexandre.fayolle&#64;camptocamp.com">alexandre.fayolle&#64;camptocamp.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/webservice/tests/test_oauth2.py
+++ b/webservice/tests/test_oauth2.py
@@ -1,12 +1,15 @@
 # Copyright 2023 Camptocamp SA
 # @author Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import base64
 import json
 import time
 from urllib.parse import quote
 
 import responses
 from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
+
+from odoo import exceptions
 
 from .common import CommonWebService, mock_cursor
 
@@ -174,6 +177,135 @@ class TestWebServiceOauth2BackendApplication(CommonWebService):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"ok": True})
+
+    @responses.activate
+    def test_fetch_token_client_secret_basic(self):
+        """Client credentials are sent as an HTTP Basic Authorization header.
+
+        Scenario:
+            1. Fetch a token with the default (HTTP Basic) authentication.
+        Expected:
+            - The token request carries a Basic Authorization header built from
+              the client id and secret.
+            - The client secret is not duplicated in the request body.
+        """
+        self.webservice.oauth2_client_auth_method = "client_secret_basic"
+        now = time.time()
+        duration = 3600
+        responses.add(
+            responses.POST,
+            f"{self.url}oauth2/token",
+            json={
+                "access_token": "cool_token",
+                "token_type": "Bearer",
+                "expires_in": duration,
+                "expires_at": now + duration,
+            },
+        )
+        responses.add(responses.GET, f"{self.url}endpoint", body="OK")
+        with mock_cursor(self.env.cr):
+            self.webservice.call("get", url=f"{self.url}endpoint")
+        token_request = responses.calls[0].request
+        expected = base64.b64encode(b"some_client_id:shh_secret").decode()
+        self.assertEqual(token_request.headers["Authorization"], f"Basic {expected}")
+        self.assertNotIn("client_secret", token_request.body or "")
+
+    @responses.activate
+    def test_fetch_token_custom_header_get(self):
+        """Client credentials are sent verbatim in a custom header over GET.
+
+        Scenario:
+            1. Configure the backend to authenticate with a custom Authorization
+               header and to request the token with a GET.
+            2. Trigger a call so a new token is fetched.
+        Expected:
+            - The token request uses the GET method.
+            - It carries the configured custom Authorization header, unaltered.
+        """
+        self.webservice.write(
+            {
+                "oauth2_client_auth_method": "custom_header",
+                "oauth2_token_method": "get",
+                "oauth2_client_auth_header": "Authorization",
+                "oauth2_client_auth_value": "SSWS some_static_token",
+            }
+        )
+        now = time.time()
+        duration = 3600
+        responses.add(
+            responses.GET,
+            f"{self.url}oauth2/token",
+            json={
+                "access_token": "cool_token",
+                "token_type": "Bearer",
+                "expires_in": duration,
+                "expires_at": now + duration,
+            },
+        )
+        responses.add(responses.GET, f"{self.url}endpoint", body="OK")
+        with mock_cursor(self.env.cr):
+            self.webservice.call("get", url=f"{self.url}endpoint")
+        token_request = responses.calls[0].request
+        self.assertEqual(token_request.method, "GET")
+        self.assertEqual(
+            token_request.headers["Authorization"], "SSWS some_static_token"
+        )
+
+    def test_client_secret_basic_auth_validation(self):
+        """HTTP Basic auth requires the client id and secret.
+
+        Scenario:
+            1. Create an OAuth2 backend with the HTTP Basic authentication but
+               without a client id and secret.
+        Expected:
+            - Validation fails asking for the client id and secret.
+        """
+        msg = (
+            r"requires 'OAuth2' authentication. However, the following "
+            r"field\(s\) are not valued: Client ID, Client Secret"
+        )
+        with self.assertRaisesRegex(exceptions.UserError, msg):
+            self.env["webservice.backend"].create(
+                {
+                    "name": "WebService OAuth2 basic missing creds",
+                    "tech_name": "test_oauth2_basic_missing",
+                    "auth_type": "oauth2",
+                    "protocol": "http",
+                    "url": self.url,
+                    "oauth2_flow": "backend_application",
+                    "oauth2_client_auth_method": "client_secret_basic",
+                    "oauth2_token_url": f"{self.url}oauth2/token",
+                }
+            )
+
+    def test_custom_header_auth_validation(self):
+        """Custom-header auth requires the header value, not the client id/secret.
+
+        Scenario:
+            1. Create an OAuth2 backend with the custom Authorization header
+               method, without a client id/secret and without a header value.
+        Expected:
+            - Validation fails asking only for the header value; the client id
+              and secret are not reported as missing.
+        """
+        msg = (
+            r"requires 'OAuth2' authentication. However, the following "
+            r"field\(s\) are not valued: Client Auth Header Value"
+        )
+        with self.assertRaisesRegex(exceptions.UserError, msg):
+            self.env["webservice.backend"].create(
+                {
+                    "name": "WebService OAuth2 custom header missing value",
+                    "tech_name": "test_oauth2_customhdr_missing",
+                    "auth_type": "oauth2",
+                    "protocol": "http",
+                    "url": self.url,
+                    "oauth2_flow": "backend_application",
+                    "oauth2_client_auth_method": "custom_header",
+                    "oauth2_client_auth_header": "Authorization",
+                    "oauth2_token_url": f"{self.url}oauth2/token",
+                }
+            )
 
 
 class TestWebServiceOauth2WebApplication(CommonWebService):

--- a/webservice/utils.py
+++ b/webservice/utils.py
@@ -4,6 +4,27 @@
 
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
+from requests.auth import AuthBase
+
+
+class StaticHeaderAuth(AuthBase):
+    """Requests auth handler injecting a static header into the request.
+
+    Useful to authenticate against endpoints expecting the credentials in a
+    non-standard Authorization header (e.g. ``Authorization: SSWS <token>``).
+    Passing it as ``auth`` (rather than via ``headers``) also prevents
+    requests-oauthlib from auto-generating an HTTP Basic ``Authorization``
+    header out of the client id, which would otherwise override ours.
+    """
+
+    def __init__(self, header, value):
+        self._header = header
+        self._value = value
+
+    def __call__(self, request):
+        request.headers[self._header] = self._value
+        return request
+
 
 def sanitize_url_for_log(url, blacklisted_keys=None):
     """Sanitize url to avoid loggin sensitive data"""

--- a/webservice/views/webservice_backend.xml
+++ b/webservice/views/webservice_backend.xml
@@ -61,7 +61,7 @@
                         />
                         <field
                             name="redirect_url"
-                            invisible="auth_type != 'oauth2' and oauth2_flow != 'web_application'"
+                            invisible="auth_type != 'oauth2' or oauth2_flow != 'web_application'"
                         />
                         <field
                             name="oauth2_client_auth_method"
@@ -92,12 +92,12 @@
                         />
                         <field
                             name="oauth2_scope"
-                            invisible="auth_type != 'oauth2' and oauth2_flow != 'web_application'"
+                            invisible="auth_type != 'oauth2' or oauth2_flow != 'web_application'"
                             required="auth_type == 'oauth2' and oauth2_flow == 'authorization_code'"
                         />
                         <field
                             name="oauth2_authorization_url"
-                            invisible="auth_type != 'oauth2' and oauth2_flow != 'web_application'"
+                            invisible="auth_type != 'oauth2' or oauth2_flow != 'web_application'"
                             required="auth_type == 'oauth2' and oauth2_flow == 'authorization_code'"
                         />
                         <field

--- a/webservice/views/webservice_backend.xml
+++ b/webservice/views/webservice_backend.xml
@@ -64,14 +64,31 @@
                             invisible="auth_type != 'oauth2' and oauth2_flow != 'web_application'"
                         />
                         <field
+                            name="oauth2_client_auth_method"
+                            invisible="auth_type != 'oauth2' or oauth2_flow != 'backend_application'"
+                            widget="radio"
+                        />
+                        <field
                             name="oauth2_clientid"
-                            invisible="auth_type != 'oauth2'"
-                            required="auth_type == 'oauth2'"
+                            invisible="auth_type != 'oauth2' or (oauth2_flow == 'backend_application' and oauth2_client_auth_method != 'client_secret_basic')"
+                            required="auth_type == 'oauth2' and (oauth2_flow != 'backend_application' or oauth2_client_auth_method == 'client_secret_basic')"
                         />
                         <field
                             name="oauth2_client_secret"
-                            invisible="auth_type != 'oauth2'"
-                            required="auth_type == 'oauth2'"
+                            invisible="auth_type != 'oauth2' or (oauth2_flow == 'backend_application' and oauth2_client_auth_method != 'client_secret_basic')"
+                            required="auth_type == 'oauth2' and (oauth2_flow != 'backend_application' or oauth2_client_auth_method == 'client_secret_basic')"
+                            password="True"
+                        />
+                        <field
+                            name="oauth2_client_auth_header"
+                            invisible="auth_type != 'oauth2' or oauth2_flow != 'backend_application' or oauth2_client_auth_method != 'custom_header'"
+                            required="auth_type == 'oauth2' and oauth2_flow == 'backend_application' and oauth2_client_auth_method == 'custom_header'"
+                        />
+                        <field
+                            name="oauth2_client_auth_value"
+                            invisible="auth_type != 'oauth2' or oauth2_flow != 'backend_application' or oauth2_client_auth_method != 'custom_header'"
+                            required="auth_type == 'oauth2' and oauth2_flow == 'backend_application' and oauth2_client_auth_method == 'custom_header'"
+                            password="True"
                         />
                         <field
                             name="oauth2_scope"
@@ -87,6 +104,12 @@
                             name="oauth2_token_url"
                             invisible="auth_type != 'oauth2'"
                             required="auth_type == 'oauth2'"
+                        />
+                        <field
+                            name="oauth2_token_method"
+                            invisible="auth_type != 'oauth2' or oauth2_flow != 'backend_application'"
+                            widget="radio"
+                            options="{'horizontal': true}"
                         />
                         <field
                             name="oauth2_audience"

--- a/webservice_server_env/models/webservice_backend.py
+++ b/webservice_server_env/models/webservice_backend.py
@@ -29,6 +29,10 @@ class WebserviceBackend(models.Model):
             "oauth2_authorization_url": {},
             "oauth2_token_url": {},
             "oauth2_audience": {},
+            "oauth2_token_method": {},
+            "oauth2_client_auth_method": {},
+            "oauth2_client_auth_header": {},
+            "oauth2_client_auth_value": {},
         }
         webservice_fields.update(base_fields)
         return webservice_fields

--- a/webservice_server_env/tests/test_oauth2.py
+++ b/webservice_server_env/tests/test_oauth2.py
@@ -104,6 +104,10 @@ oauth2_authorization_url = {url}/authorize
                     ws_form.api_key_header = "Test Api Key Header"
                 if auth_type == "oauth2":
                     ws_form.oauth2_flow = oauth2_flow
+                    # ``oauth2_client_auth_method`` is only shown (and drives the
+                    # visibility of the client id/secret) for the backend flow.
+                    if oauth2_flow == "backend_application":
+                        ws_form.oauth2_client_auth_method = "client_secret_basic"
                     ws_form.oauth2_clientid = "Test Client ID"
                     ws_form.oauth2_client_secret = "Test Client Secret"
                     ws_form.oauth2_token_url = f"{url}oauth2/token"
@@ -122,6 +126,8 @@ oauth2_authorization_url = {url}/authorize
                 ws_form.auth_type = new_auth_type
                 if new_auth_type == "oauth2":
                     ws_form.oauth2_flow = oauth2_flow
+                    if oauth2_flow == "backend_application":
+                        ws_form.oauth2_client_auth_method = "client_secret_basic"
                     ws_form.oauth2_clientid = "Test Client ID"
                     ws_form.oauth2_client_secret = "Test Client Secret"
                     ws_form.oauth2_token_url = f"{url}oauth2/token"


### PR DESCRIPTION
Some providers require the credentials in a non-standard Authorization header (for instance Okta uses `Authorization: SSWS <token>`).

This PR makes it possible. Such an endpoint can be configured as:

    Auth Type             = OAuth2
    OAuth2 Flow           = Backend Application (Client Credentials Grant)
    Token URL             = https://provider.example.com/oauth2/token
    Client Authentication = Custom Authorization header
    Client Auth Header    = Authorization
    Client Auth Value     = SSWS <token>

Additionally, the provider might only reply to `GET` instead of `POST`, so the token request method is configurable now too.