### PR TITLE
[FIX] endpoint: use self.patch for _endpoint_route_prefix in test_routing

### DIFF
--- a/endpoint/tests/test_endpoint.py
+++ b/endpoint/tests/test_endpoint.py
@@ -168,7 +168,7 @@ class TestEndpoint(CommonEndpoint):
             },
         )
         # check prefix
-        type(endpoint)._endpoint_route_prefix = "/foo"
+        self.patch(type(endpoint), "_endpoint_route_prefix", "/foo")
         endpoint._compute_route()
         __, info, __ = endpoint._get_routing_info()
         self.assertEqual(
@@ -182,7 +182,6 @@ class TestEndpoint(CommonEndpoint):
                 "readonly": False,
             },
         )
-        type(endpoint)._endpoint_route_prefix = ""
 
     @mute_logger("odoo.modules.registry")
     def test_unlink(self):


### PR DESCRIPTION
Manually reassigning type(endpoint)._endpoint_route_prefix leaves a residual class attribute directly on endpoint.endpoint (the field is only defined on the EndpointRouteHandler mixin), which Odoo's test harness now flags as an unexpected class mutation after the test. Use self.patch() so the attribute is properly restored (deleted) on cleanup.
