### PR TITLE
[19.0][Fix]`endpoint_route_handler`: Restore registry._init_modules after mocked request

### DIFF
--- a/endpoint_route_handler/tests/common.py
+++ b/endpoint_route_handler/tests/common.py
@@ -38,6 +38,8 @@ class CommonEndpoint(TransactionCase):
     def _get_mocked_request(
         self, env=None, httprequest=None, extra_headers=None, request_attrs=None
     ):
+        registry = (env or self.env).registry
+        original_init_modules = registry._init_modules
         with MockRequest(env or self.env) as mocked_request:
             mocked_request.httprequest = (
                 DotDict(httprequest) if httprequest else mocked_request.httprequest
@@ -51,3 +53,7 @@ class CommonEndpoint(TransactionCase):
             mocked_request.make_response = lambda data, **kw: data
             mocked_request.registry._init_modules = set()
             yield mocked_request
+        # Restore the real _init_modules.
+        # Without this, routing_map() keeps being built with an empty module
+        # set and post_install HttpCase tests in other modules get 404s.
+        registry._init_modules = original_init_modules


### PR DESCRIPTION
`_get_mocked_request()` sets `registry._init_modules = set()` to simulate a minimal endpoint environment. Since registry is the real Odoo Registry singleton, this mutation persisted after the context exited.

Odoo core `ir_http.py` uses `registry._init_modules` to build the routing map, so leaving it as set() caused post_install HttpCase tests from other modules to receive a routing map containing only server-wide modules, resulting in 404 errors on routes registered by those modules.

Fix by saving and restoring _init_modules in a try/finally block.