### PR TITLE
[19.0][FIX] endpoint: validate registry sync

### DIFF
--- a/endpoint/__manifest__.py
+++ b/endpoint/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Endpoint",
     "summary": """Provide custom endpoint machinery.""",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.2.1",
     "license": "LGPL-3",
     "development_status": "Beta",
     "author": "Camptocamp,Odoo Community Association (OCA)",

--- a/endpoint/models/endpoint_mixin.py
+++ b/endpoint/models/endpoint_mixin.py
@@ -3,6 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import json
+import symtable
 import textwrap
 
 import jsonschema
@@ -41,6 +42,46 @@ hashlib = safe_eval.wrap_module(
 hmac = safe_eval.wrap_module(
     __import__("hmac"),
     ["new", "compare_digest"],
+)
+
+_SAFE_EVAL_BUILTINS = frozenset(
+    {
+        "Exception",
+        "False",
+        "None",
+        "True",
+        "abs",
+        "all",
+        "any",
+        "bool",
+        "bytes",
+        "chr",
+        "dict",
+        "divmod",
+        "enumerate",
+        "filter",
+        "float",
+        "int",
+        "isinstance",
+        "len",
+        "list",
+        "map",
+        "max",
+        "min",
+        "ord",
+        "range",
+        "reduce",
+        "repr",
+        "round",
+        "set",
+        "sorted",
+        "str",
+        "sum",
+        "tuple",
+        "unicode",
+        "xrange",
+        "zip",
+    }
 )
 
 
@@ -97,6 +138,76 @@ class EndpointMixin(models.AbstractModel):
                     "Exec mode is set to `Code`: you must provide a piece of code"
                 )
             )
+
+    def _registry_sync_errors(self):
+        errors = super()._registry_sync_errors()
+        snippet = self.code_snippet or ""
+        try:
+            syntax_error = safe_eval.test_python_expr(snippet, mode="exec")
+        except NameError as error:
+            syntax_error = str(error)
+        if syntax_error:
+            errors.append(
+                self.env._("Invalid code snippet: %(error)s", error=syntax_error)
+            )
+            return errors
+
+        unavailable_names = self._code_snippet_unavailable_names(snippet)
+        if unavailable_names:
+            errors.append(
+                self.env._(
+                    "The code snippet uses unavailable variable(s): %(names)s. "
+                    "Available system variables are: %(available_names)s.",
+                    names=", ".join(unavailable_names),
+                    available_names=", ".join(
+                        sorted(self._code_snippet_system_variable_names())
+                    ),
+                )
+            )
+        return errors
+
+    def _code_snippet_system_variable_names(self):
+        return {
+            "Response",
+            "datetime",
+            "dateutil",
+            "endpoint",
+            "env",
+            "exceptions",
+            "hashlib",
+            "hmac",
+            "json",
+            "log",
+            "request",
+            "time",
+            "user",
+            "werkzeug",
+        }
+
+    def _code_snippet_unavailable_names(self, snippet):
+        """Find global names that safe_eval will not provide at runtime."""
+        symbol_table = symtable.symtable(snippet, "<endpoint>", "exec")
+        referenced_globals = set()
+
+        def collect_globals(table):
+            for symbol in table.get_symbols():
+                if symbol.is_referenced() and symbol.is_global():
+                    referenced_globals.add(symbol.get_name())
+            for child in table.get_children():
+                collect_globals(child)
+
+        collect_globals(symbol_table)
+        assigned_names = {
+            symbol.get_name()
+            for symbol in symbol_table.get_symbols()
+            if symbol.is_assigned() or symbol.is_imported()
+        }
+        available_names = (
+            self._code_snippet_system_variable_names()
+            | _SAFE_EVAL_BUILTINS
+            | assigned_names
+        )
+        return sorted(referenced_globals - available_names)
 
     def _get_request_content_schema_applicable_for_types(self):
         """Content types for which ``request_content_schema`` applies."""

--- a/endpoint/tests/test_endpoint.py
+++ b/endpoint/tests/test_endpoint.py
@@ -246,6 +246,79 @@ class TestEndpoint(CommonEndpoint):
                 partial_func.func.__name__, "_handle_registry_sync_post_commit"
             )
 
+    def test_invalid_route_can_be_saved_but_not_synchronized(self):
+        endpoint = self.env["endpoint.endpoint"].create(
+            {
+                "name": "Invalid route",
+                "route": "/invalid/<date:value>",
+                "exec_mode": "code",
+                "code_snippet": 'result = {"payload": "ok"}',
+                "request_method": "GET",
+                "auth_type": "user_endpoint",
+            }
+        )
+        registry = endpoint._endpoint_registry
+        key = endpoint._endpoint_registry_unique_key()
+        self.assertEqual(registry._get_rule(key), None)
+
+        with (
+            self.assertRaisesRegex(exceptions.UserError, "converter 'date'"),
+            self.env.cr.savepoint(),
+        ):
+            endpoint.registry_sync = True
+        self.assertEqual(registry._get_rule(key), None)
+
+        endpoint.route = "/valid/<string:value>"
+        endpoint._handle_registry_sync()
+        self.assertEqual(registry._get_rule(key).route, "/valid/<string:value>")
+
+    def test_inactive_invalid_route_can_be_removed_from_registry(self):
+        endpoint = self.env["endpoint.endpoint"].create(
+            {
+                "name": "Route to remove",
+                "route": "/route/to/remove",
+                "exec_mode": "code",
+                "code_snippet": 'result = {"payload": "ok"}',
+                "request_method": "GET",
+                "auth_type": "user_endpoint",
+            }
+        )
+        registry = endpoint._endpoint_registry
+        key = endpoint._endpoint_registry_unique_key()
+        endpoint._handle_registry_sync()
+        self.assertIsNotNone(registry._get_rule(key))
+
+        endpoint.write({"route": "/invalid/<date:value>", "active": False})
+        endpoint._handle_registry_sync()
+        self.assertEqual(registry._get_rule(key), None)
+
+    def test_invalid_code_can_be_saved_but_not_synchronized(self):
+        endpoint = self.env["endpoint.endpoint"].create(
+            {
+                "name": "Invalid code",
+                "route": "/invalid/code",
+                "exec_mode": "code",
+                "code_snippet": "result = date(request.params.get('since'))",
+                "request_method": "GET",
+                "auth_type": "user_endpoint",
+            }
+        )
+        with self.assertRaisesRegex(exceptions.UserError, "unavailable.*date"):
+            endpoint._handle_registry_sync()
+
+        endpoint.code_snippet = "result = {"
+        with self.assertRaisesRegex(exceptions.UserError, "Invalid code snippet"):
+            endpoint._handle_registry_sync()
+
+    def test_locally_defined_code_variables_are_available(self):
+        self.endpoint.code_snippet = textwrap.dedent(
+            """
+            value = request.params.get("value")
+            result = {"payload": value}
+            """
+        )
+        self.assertEqual(self.endpoint._registry_sync_errors(), [])
+
     def test_duplicate(self):
         endpoint = self.endpoint.copy()
         self.assertTrue(endpoint.route.endswith("/COPY_FIXME"))

--- a/endpoint_route_handler/__manifest__.py
+++ b/endpoint_route_handler/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Endpoint route handler",
     "summary": """Provide mixin and tool to generate custom endpoints on the fly.""",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.2.1",
     "license": "LGPL-3",
     "development_status": "Beta",
     "author": "Camptocamp,Odoo Community Association (OCA)",

--- a/endpoint_route_handler/models/endpoint_route_handler.py
+++ b/endpoint_route_handler/models/endpoint_route_handler.py
@@ -4,6 +4,8 @@
 
 import logging
 
+import werkzeug
+
 from odoo import api, exceptions, fields, models
 
 ENDPOINT_ROUTE_CONSUMER_MODELS = {
@@ -187,6 +189,26 @@ class EndpointRouteHandler(models.AbstractModel):
                     )
                 )
 
+    def _registry_sync_errors(self):
+        errors = super()._registry_sync_errors()
+        try:
+            routing_map = werkzeug.routing.Map(
+                strict_slashes=False,
+                converters=self.env["ir.http"]._get_converters(),
+            )
+            rule = werkzeug.routing.Rule(self.route)
+            rule.merge_slashes = False
+            routing_map.add(rule)
+        except (LookupError, TypeError, ValueError) as error:
+            errors.append(
+                self.env._(
+                    "Invalid route %(route)s: %(error)s",
+                    route=self.route,
+                    error=error,
+                )
+            )
+        return errors
+
     @api.constrains("request_method", "request_content_type")
     def _check_request_method(self):
         for rec in self:
@@ -207,6 +229,7 @@ class EndpointRouteHandler(models.AbstractModel):
     # TODO: consider if useful or not for single records
     def _register_single_controller(self, options=None, key=None, init=False):
         """Shortcut to register one single controller."""
+        self._validate_registry_sync(active_only=False)
         rule = self._make_controller_rule(options=options, key=key)
         self._endpoint_registry.update_rules([rule], init=init)
         self.env.registry.clear_cache("routing")

--- a/endpoint_route_handler/models/endpoint_route_sync_mixin.py
+++ b/endpoint_route_handler/models/endpoint_route_sync_mixin.py
@@ -6,6 +6,7 @@ import logging
 from functools import partial
 
 from odoo import api, fields, models
+from odoo.exceptions import UserError
 
 from ..registry import EndpointRegistry
 
@@ -43,6 +44,8 @@ class EndpointRouteSyncMixin(models.AbstractModel):
         if any([x in vals for x in self._routing_impacting_fields() + ("active",)]):
             # Mark as out of sync
             vals["registry_sync"] = False
+        if vals.get("registry_sync"):
+            self._validate_registry_sync()
         res = super().write(vals)
         if vals.get("registry_sync"):
             # NOTE: this is not done on create to allow bulk reload of the envs
@@ -50,6 +53,34 @@ class EndpointRouteSyncMixin(models.AbstractModel):
             # on one or more records in a row.
             self._add_after_commit_hook(self.ids)
         return res
+
+    def _registry_sync_errors(self):
+        """Return errors preventing this record from being registered."""
+        self.ensure_one()
+        return []
+
+    def _validate_registry_sync(self, active_only=True):
+        """Prevent invalid records from reaching the route registry."""
+        invalid_records = []
+        records = self.filtered("active") if active_only else self
+        for record in records:
+            errors = record._registry_sync_errors()
+            if errors:
+                invalid_records.append(
+                    self.env._(
+                        "%(name)s:\n- %(errors)s",
+                        name=record.display_name,
+                        errors="\n- ".join(errors),
+                    )
+                )
+        if invalid_records:
+            raise UserError(
+                self.env._(
+                    "The registry cannot be synchronized because some active "
+                    "records are invalid:\n\n%(errors)s",
+                    errors="\n\n".join(invalid_records),
+                )
+            )
 
     @api.model
     def _add_after_commit_hook(self, record_ids):
@@ -91,6 +122,7 @@ class EndpointRouteSyncMixin(models.AbstractModel):
     def _register_controllers(self, init=False, options=None, clear_cache=True):
         if not self:
             return
+        self._validate_registry_sync(active_only=False)
         rules = self._prepare_endpoint_rules(options=options)
         self._endpoint_registry.update_rules(rules, init=init)
         if clear_cache:

--- a/endpoint_route_handler/tests/test_endpoint.py
+++ b/endpoint_route_handler/tests/test_endpoint.py
@@ -3,7 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from contextlib import contextmanager
 
-from odoo import api, modules
+from odoo import api, exceptions, modules
 from odoo.tests import common
 from odoo.tools import mute_logger
 
@@ -49,6 +49,26 @@ class TestEndpoint(CommonEndpoint):
         self.assertTrue(first_hash)
         new_route.route += "/new"
         self.assertNotEqual(new_route.endpoint_hash, first_hash)
+
+    def test_invalid_route_cannot_be_registered(self):
+        for route, error in (
+            ("/my/test/<date:value>", "converter 'date' does not exist"),
+            ("/my/test/<value", "malformed url rule"),
+        ):
+            with self.subTest(route=route):
+                new_route = make_new_route(self.env, route=route)
+                with self.assertRaisesRegex(exceptions.UserError, error):
+                    new_route._register_controllers()
+
+    def test_inactive_invalid_route_can_be_synchronized(self):
+        new_route = make_new_route(
+            self.env,
+            route="/my/test/<date:value>",
+            active=False,
+        )
+        new_route._validate_registry_sync()
+        with self.assertRaisesRegex(exceptions.UserError, "converter 'date'"):
+            new_route._register_controllers()
 
     def test_auth_type_routing_info(self):
         for auth_type in ("public", "user_endpoint", "bearer"):


### PR DESCRIPTION
## What changed

- validate active endpoint records before scheduling a registry synchronization
- compile dynamic routes with the exact converters exposed by `ir.http`
- validate endpoint snippets against `safe_eval` syntax and detect unavailable global variables
- keep invalid endpoints editable while preventing them from reaching `endpoint_route`
- keep invalid inactive endpoints synchronizable so stale registry rules can be removed
- repeat validation in controller registration methods as a defense for programmatic callers

## Why

Werkzeug compiles every registered URL rule while Odoo builds its global routing map. A dynamic endpoint using an unknown converter, such as `<date:value>`, raises a `LookupError` and prevents the entire routing map from being built. This makes every application route return an error, not only the invalid endpoint.

Endpoint code snippets can also reference names that are not part of the `safe_eval` context. For example, `date(...)` is not available, while `datetime` is.

The endpoint model already separates editing from publication through the `registry_sync` action. This change uses that boundary to report actionable errors without preventing users from saving an invalid draft.

## User impact

When an active invalid endpoint is synchronized, the user now receives a `UserError` listing the affected endpoint and its route or code errors. No invalid rule is written to the registry. After correcting the endpoint, the same synchronization action publishes it normally.

## Validation

- OCA pre-commit suite: passed
- Odoo 19.0 CI image (`py3.10-odoo19.0`): 68 tests, 0 failures, 0 errors
- regression tests cover unknown and malformed route converters, invalid `safe_eval` syntax, unavailable system variables, draft persistence, successful synchronization after correction, and removal of an invalid inactive route
