### PR TITLE
[17.0][FIX] `endpoint_auth_api_key`: expect 401 when API key is missing

### DIFF
--- a/endpoint_auth_api_key/tests/test_endpoint_controller.py
+++ b/endpoint_auth_api_key/tests/test_endpoint_controller.py
@@ -41,7 +41,7 @@ class EndpoinAuthApikeytHttpCase(HttpCase):
     def test_call_no_key(self):
         route = "/demo/api/key"
         response = self._make_request(route)
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
 
     def test_call_good_key(self):
         route = "/demo/api/key"


### PR DESCRIPTION
The `auth_api_key` authentication handler now raises `Unauthorized`: 401 for missing credentials. Update the stale assertion accordingly while retaining `403` for authenticated API keys that lack endpoint permission.