### PR TITLE
[FIX] endpoint_route_handler: build routing map without a bound request

### DIFF
--- a/endpoint_route_handler/models/ir_http.py
+++ b/endpoint_route_handler/models/ir_http.py
@@ -28,10 +28,9 @@ class IrHttp(models.AbstractModel):
             self._endpoint_routing_rules(),
         )
 
-    @classmethod
-    def _endpoint_routing_rules(cls):
+    def _endpoint_routing_rules(self):
         """Yield custom endpoint rules"""
-        e_registry = cls._endpoint_route_registry(http.request.env)
+        e_registry = self._endpoint_route_registry(self.env)
         for endpoint_rule in e_registry.get_rules():
             _logger.debug("LOADING %s", endpoint_rule)
             endpoint = endpoint_rule.endpoint
@@ -43,9 +42,8 @@ class IrHttp(models.AbstractModel):
         res = super().routing_map(key=key)
         return res
 
-    @classmethod
-    def _endpoint_route_last_version(cls):
-        res = cls._get_routing_map_last_version(http.request.env)
+    def _endpoint_route_last_version(self):
+        res = self._get_routing_map_last_version(self.env)
         return res
 
     @classmethod

--- a/endpoint_route_handler/readme/CONTRIBUTORS.md
+++ b/endpoint_route_handler/readme/CONTRIBUTORS.md
@@ -1,2 +1,3 @@
 - Simone Orsi \<<simone.orsi@camptocamp.com>\>
 - Nguyen Minh Chien \<<chien@trobz.com>\>
+- Omar Assouma \<<omar.assouma@dataone.eu>\>

--- a/endpoint_route_handler/tests/test_endpoint.py
+++ b/endpoint_route_handler/tests/test_endpoint.py
@@ -42,6 +42,14 @@ class TestEndpoint(CommonEndpoint):
         EndpointRegistry.wipe_registry_for(self.env.cr)
         super().tearDown()
 
+    def test_routing_map_no_request(self):
+        # Crons, `odoo shell` and core tests build the routing map with no
+        # request bound. website's TestWebsiteTechnicalPage does, through
+        # website.technical.page.get_static_routes(). No mocked request here
+        # on purpose.
+        self.env.registry.clear_cache("routing")
+        self.assertTrue(self.env["ir.http"].routing_map())
+
     def test_as_tool_base_data(self):
         new_route = make_new_route(self.env)
         self.assertEqual(new_route.route, "/my/test/route")


### PR DESCRIPTION
## Problem

`routing_map()` raises `RuntimeError: object is not bound` whenever it is called with no HTTP request in flight.

Both helpers this module adds to `ir.http` are classmethods, so neither has `self.env`, and both reach the endpoint registry through `http.request.env`:

```python
@classmethod
def _endpoint_routing_rules(cls):
    e_registry = cls._endpoint_route_registry(http.request.env)

@classmethod
def _endpoint_route_last_version(cls):
    res = cls._get_routing_map_last_version(http.request.env)
```

The second one sits in the ormcache key of `routing_map`, so it runs before the wrapped body and the failure happens while computing the key.

## How to reproduce

One line in `odoo shell`, on a database with `endpoint_route_handler` installed:

```python
env['ir.http'].routing_map()
```

```
File ".../endpoint_route_handler/models/ir_http.py", line 48, in _endpoint_route_last_version
    res = cls._get_routing_map_last_version(http.request.env)
File ".../werkzeug/local.py", line 509, in _get_current_object
    raise RuntimeError(unbound_message)
RuntimeError: object is not bound
```

Odoo 19 reaches it through core too. `website.technical.page` builds its SQL view from `get_static_routes()`, which walks the routing map, and `website`'s `TestWebsiteTechnicalPage` exercises that from a `TransactionCase`. On a database with this module installed, `website_hr_recruitment`'s `TestWebsiteHrRecruitmentTechnicalPage` errors out. Crons and shell scripts hit the same wall.

The existing tests never caught it because they all wrap their calls in `MockRequest`, so a request was always present.

## Fix

`routing_map()` is a model method, so `self.env` already holds a cursor. The request was never needed. Both helpers become instance methods reading `self.env`.

They are only ever called as `self.<method>()` from this module, and the tests already call `_endpoint_route_last_version()` on a recordset, so no call site changes.

`last_version()` reads a sequence, so any cursor on the database returns the same value and the cache key is unchanged. `TestEndpointCrossEnv` still passes: I checked two separate envs and both report the same version.

## Test

Added a regression test that builds the map with no request bound.