### PR TITLE
[18.0][FIX] webservice: reset oauth2_flow regardless of server_environment

### DIFF
--- a/webservice/models/webservice_backend.py
+++ b/webservice/models/webservice_backend.py
@@ -100,6 +100,30 @@ class WebserviceBackend(models.Model):
         extra_params = ("auth_type",)
         return name in extra_params or super()._valid_field_parameter(field, name)
 
+    @api.onchange("auth_type")
+    def _onchange_auth_type(self):
+        # Keep `oauth2_flow` in sync in the UI as the user edits `auth_type`,
+        # regardless of whether `server_environment` is installed (see
+        # `create`/`write` below for the same guarantee on any other write).
+        if self.auth_type != "oauth2":
+            self.oauth2_flow = False
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        records.filtered(
+            lambda r: r.auth_type != "oauth2" and r.oauth2_flow
+        ).oauth2_flow = False
+        return records
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "auth_type" in vals:
+            self.filtered(
+                lambda r: r.auth_type != "oauth2" and r.oauth2_flow
+            ).oauth2_flow = False
+        return res
+
     def call(self, method, *args, **kwargs):
         _logger.debug("backend %s: call %s %s %s", self.name, method, args, kwargs)
         response = getattr(self._get_adapter(), method)(*args, **kwargs)

--- a/webservice/tests/test_oauth2.py
+++ b/webservice/tests/test_oauth2.py
@@ -271,3 +271,64 @@ class TestWebServiceOauth2WebApplication(CommonWebService):
             self.assertEqual(
                 ws.oauth2_flow, oauth2_flow if ws.auth_type == "oauth2" else False
             )
+
+
+class TestWebServiceOauth2FlowReset(CommonWebService):
+    """``oauth2_flow`` must be reset on any write, not only via the UI.
+
+    This is a plain ORM-level guarantee independent of ``server_environment``
+    (see ``webservice_server_env`` for the extra guarantee that applies when
+    that module is installed).
+    """
+
+    @classmethod
+    def _setup_records(cls):
+        res = super()._setup_records()
+        cls.url = "https://localhost.demo.odoo/"
+        cls.webservice = cls.env["webservice.backend"].create(
+            {
+                "name": "WebService OAuth2",
+                "tech_name": "test_oauth2_reset",
+                "auth_type": "oauth2",
+                "protocol": "http",
+                "url": cls.url,
+                "oauth2_flow": "backend_application",
+                "content_type": "application/xml",
+                "oauth2_clientid": "some_client_id",
+                "oauth2_client_secret": "shh_secret",
+                "oauth2_token_url": f"{cls.url}oauth2/token",
+                "oauth2_audience": cls.url,
+            }
+        )
+        return res
+
+    def test_write_resets_oauth2_flow_when_auth_type_changes(self):
+        self.webservice.write({"auth_type": "none"})
+        self.assertFalse(self.webservice.oauth2_flow)
+
+    def test_write_keeps_oauth2_flow_when_auth_type_stays_oauth2(self):
+        self.webservice.write({"oauth2_client_secret": "new_secret"})
+        self.assertEqual(self.webservice.oauth2_flow, "backend_application")
+
+    def test_create_resets_oauth2_flow_for_non_oauth2_auth_type(self):
+        ws = self.env["webservice.backend"].create(
+            {
+                "name": "WebService No Auth",
+                "tech_name": "test_oauth2_reset_create",
+                "auth_type": "none",
+                "protocol": "http",
+                "url": self.url,
+                # Inconsistent on purpose: no `create`/`write` should ever
+                # leave this set together with a non-oauth2 `auth_type`.
+                "oauth2_flow": "backend_application",
+            }
+        )
+        self.assertFalse(ws.oauth2_flow)
+
+    def test_onchange_resets_oauth2_flow(self):
+        ws = self.webservice.new(
+            {"auth_type": "oauth2", "oauth2_flow": "backend_application"}
+        )
+        ws.auth_type = "none"
+        ws._onchange_auth_type()
+        self.assertFalse(ws.oauth2_flow)


### PR DESCRIPTION
#146 split server_environment out of `webservice` into the optional `webservice_server_env` module, but the logic resetting `oauth2_flow` when `auth_type` is no longer "oauth2" only lived in `webservice_server_env`'s `_compute_server_env` override.

Without `server_environment` installed, switching a backend's `auth_type` away from "oauth2" (via the UI or a plain write) silently left a stale `oauth2_flow`, which `_get_adapter_protocol` would then still factor into the selected component.

Add an `_onchange_auth_type` plus `create`/`write` overrides on `webservice.backend` itself so the reset is guaranteed unconditionally, independent of `server_environment`. `webservice_server_env`'s own override is unchanged and still covers its own case (env-var-driven values).

CC @yankinmax @gurneyalex 